### PR TITLE
Introduce new rules for Plinth

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ So far, Plu-Stan implements the following rules:
 | PLU-STAN-02 | Usage of 'unsafeFromBuiltinData' can lead to unexpected behavior | Security    | High      |
 | PLU-STAN-03 | Usage of Optional types in on chain code. |           | Security    | Medium    |
 | PLU-STAN-04 | Usage of 'eq instance' on script hash, public key hash and payment credential | Security    | Medium    |
+| PLU-STAN-05 | Usage of higher-order helpers like 'all', 'any', and 'find' in on-chain code | Performance | Medium    |
+| PLU-STAN-06 | Multiple list traversals in on-chain code | Performance | Medium    |
+| PLU-STAN-07 | Guard syntax in on-chain code | Performance | Medium    |
+| PLU-STAN-08 | Non-strict let binding used multiple times | Performance | Medium    |
+| PLU-STAN-09 | valueOf in boolean conditions | Security    | Medium    |
 
 ## Usage
 [[Back to the Table of Contents] ↑](#table-of-contents)

--- a/src/Stan/Inspection.hs
+++ b/src/Stan/Inspection.hs
@@ -116,6 +116,10 @@ data InspectionAnalysis
     | PatternMatchOn_
     -- | Replace multiple comparison operations with 'compare'
     | UseCompare
+    -- | Non-strict let binding used multiple times.
+    | NonStrictLetMultiUse
+    -- | 'valueOf' used in boolean comparisons.
+    | ValueOfInComparison
     deriving stock (Show, Eq)
 
 -- | Show 'Inspection' in a human-friendly format.

--- a/target/Target/PlutusTx.hs
+++ b/target/Target/PlutusTx.hs
@@ -1,11 +1,16 @@
-module Target.PlutusTx where
+{-# LANGUAGE BangPatterns #-}
+
+module Target.PlutusTx (assocMap, unsafeFromBuiltinData, usageOfPTxMaybe, pubKeyHashEq, scriptHashEq, credentialHashEq, credentialHashLe, hoListFilter, hoFoldableLength, nestedMapFilter, guardedLog2, nonStrictLetTwice, strictLetTwice, nonStrictLetUsedInBindings, nonStrictLetUsedInBindingAndBody, valueOfEqInput, valueOfEqLet, valueOfEqReversed, valueOfEqPrefix, valueOfEqSection) where
 
 import qualified PlutusTx as Tx
 import qualified PlutusTx.AssocMap as AssocMap
+import qualified PlutusTx.Foldable as TxFoldable
 import qualified PlutusTx.Maybe as Maybe
+import qualified PlutusTx.List as TxList
 
 -- Place for future imports
 import PlutusLedgerApi.V1 (Credential (..), PubKeyHash (..), ScriptHash (..))
+import qualified PlutusLedgerApi.V1.Value as Value
 {-# ANN module ("onchain-contract" :: String) #-}
 --
 --
@@ -64,3 +69,105 @@ credentialHashLe = credentialHash < credentialHash
   where
     credentialHash :: Credential
     credentialHash = error "tbd"
+
+hoListFilter :: [Integer]
+hoListFilter =
+  TxList.filter ((>) 0) [1, 2, 3]
+
+hoFoldableLength :: Integer
+hoFoldableLength =
+  TxFoldable.length ([1, 2, 3] :: [Integer])
+
+nestedMapFilter :: [Integer]
+nestedMapFilter =
+  let exList = [1, 2, 3, 4]
+  in TxList.map ((+) 100) $ TxList.filter ((>) 0) exList
+
+guardedLog2 :: Integer -> Integer
+guardedLog2 n
+  | n == 0 = 0
+  | n == 1 = 1
+  | n `mod` 2 == 0 = 1 + guardedLog2 (n `div` 2)
+  | otherwise = n
+
+nonStrictLetTwice :: Integer
+nonStrictLetTwice =
+  let tup = (1, 2)
+  in fst tup + snd tup
+
+strictLetTwice :: Integer
+strictLetTwice =
+  let !tup = (1, 2)
+  in fst tup + snd tup
+
+nonStrictLetUsedInBindings :: Integer
+nonStrictLetUsedInBindings =
+  let tup = (1, 2)
+      a = fst tup
+      b = snd tup
+  in a + b
+
+nonStrictLetUsedInBindingAndBody :: Integer
+nonStrictLetUsedInBindingAndBody =
+  let tup = (1, 2)
+      a = fst tup
+  in a + snd tup
+
+valueOfEqInput :: Bool
+valueOfEqInput =
+  Value.valueOf inputValue adaCS adaToken == 5000
+  where
+    inputValue :: Value.Value
+    inputValue = Value.singleton adaCS adaToken 5000
+    adaCS :: Value.CurrencySymbol
+    adaCS = Value.adaSymbol
+    adaToken :: Value.TokenName
+    adaToken = Value.adaToken
+
+valueOfEqLet :: Bool
+valueOfEqLet =
+  let adaAmountInput = Value.valueOf inputValue adaCS adaToken
+      adaAmountOutput = Value.valueOf outputValue adaCS adaToken
+  in adaAmountInput == adaAmountOutput
+  where
+    inputValue :: Value.Value
+    inputValue = Value.singleton adaCS adaToken 5000
+    outputValue :: Value.Value
+    outputValue = Value.singleton adaCS adaToken 5000
+    adaCS :: Value.CurrencySymbol
+    adaCS = Value.adaSymbol
+    adaToken :: Value.TokenName
+    adaToken = Value.adaToken
+
+valueOfEqReversed :: Bool
+valueOfEqReversed =
+  5000 == Value.valueOf inputValue adaCS adaToken
+  where
+    inputValue :: Value.Value
+    inputValue = Value.singleton adaCS adaToken 5000
+    adaCS :: Value.CurrencySymbol
+    adaCS = Value.adaSymbol
+    adaToken :: Value.TokenName
+    adaToken = Value.adaToken
+
+valueOfEqPrefix :: Bool
+valueOfEqPrefix =
+  (==) (Value.valueOf inputValue adaCS adaToken) 5000
+  where
+    inputValue :: Value.Value
+    inputValue = Value.singleton adaCS adaToken 5000
+    adaCS :: Value.CurrencySymbol
+    adaCS = Value.adaSymbol
+    adaToken :: Value.TokenName
+    adaToken = Value.adaToken
+
+valueOfEqSection :: Bool
+valueOfEqSection =
+  (== 5000) (Value.valueOf inputValue adaCS adaToken)
+  where
+    inputValue :: Value.Value
+    inputValue = Value.singleton adaCS adaToken 5000
+    adaCS :: Value.CurrencySymbol
+    adaCS = Value.adaSymbol
+    adaToken :: Value.TokenName
+    adaToken = Value.adaToken

--- a/test/Test/Stan/Analysis.hs
+++ b/test/Test/Stan/Analysis.hs
@@ -55,7 +55,7 @@ analysisSpec hieFiles = describe "Static Analysis" $ do
 analysisExtensionsSpec :: Analysis -> Spec
 analysisExtensionsSpec Analysis{..} = describe "Used extensions" $ do
     it "should correctly count total amount of used extensions" $
-        Set.size (fst analysisUsedExtensions) `shouldBe` 16
+        Set.size (fst analysisUsedExtensions) `shouldBe` 17
     it "should correctly count total amount of used safe extensions" $
         Set.size (snd analysisUsedExtensions) `shouldBe` 0
 

--- a/test/Test/Stan/Analysis/PlutusTx.hs
+++ b/test/Test/Stan/Analysis/PlutusTx.hs
@@ -5,7 +5,7 @@ module Test.Stan.Analysis.PlutusTx (
 import Test.Hspec (Spec, describe, it)
 
 import Stan.Analysis (Analysis)
-import Test.Stan.Analysis.Common (observationAssert)
+import Test.Stan.Analysis.Common (noObservationAssert, observationAssert)
 
 import qualified Stan.Inspection.AntiPattern as AntiPattern
 
@@ -14,22 +14,58 @@ analysisPlutusTxSpec analysis = describe "Plutus-Tx" $ do
   let checkObservation = observationAssert ["PlutusTx"] analysis
 
   it "PLU-STAN-01: PlutusTx.AssocMap unsafeFromList" $
-    checkObservation AntiPattern.plustan01 33 12 35
+    checkObservation AntiPattern.plustan01 38 12 35
 
   it "PLU-STAN-02: PlutusTx.UnsafeFromData unsafeFromBuiltinData" $
-    checkObservation AntiPattern.plustan02 37 3 27
+    checkObservation AntiPattern.plustan02 42 3 27
 
   it "PLU-STAN-03: No usage of Optional types in on-chain code" $
-    checkObservation AntiPattern.plustan03 41 7 22
+    checkObservation AntiPattern.plustan03 46 7 22
 
   it "PLU-STAN-04: == on pubKeyHash" $
-    checkObservation AntiPattern.plustan04 45 27 29
+    checkObservation AntiPattern.plustan04 50 27 29
 
   it "PLU-STAN-04: == on scriptHash" $
-    checkObservation AntiPattern.plustan04 51 27 29
+    checkObservation AntiPattern.plustan04 56 27 29
 
   it "PLU-STAN-04: == on credentialHash" $
-    checkObservation AntiPattern.plustan04 57 35 37
+    checkObservation AntiPattern.plustan04 62 35 37
 
   it "PLU-STAN-04: < on credentialHash" $
-    checkObservation AntiPattern.plustan04 63 35 36
+    checkObservation AntiPattern.plustan04 68 35 36
+
+  it "PLU-STAN-05: higher-order list helpers" $
+    checkObservation AntiPattern.plustan05 75 3 16
+
+  it "PLU-STAN-06: nested list traversals" $
+    checkObservation AntiPattern.plustan06 84 6 57
+
+  it "PLU-STAN-07: guard syntax in on-chain code" $
+    checkObservation AntiPattern.plustan07 88 5 11
+
+  it "PLU-STAN-08: non-strict let binding used multiple times" $
+    checkObservation AntiPattern.plustan08 95 7 19
+
+  it "PLU-STAN-08: strict let binding does not trigger" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan08 100
+
+  it "PLU-STAN-08: non-strict binding used in sibling let bindings" $
+    checkObservation AntiPattern.plustan08 105 7 19
+
+  it "PLU-STAN-08: non-strict binding used in a let binding and the body" $
+    checkObservation AntiPattern.plustan08 112 7 19
+
+  it "PLU-STAN-09: valueOf compared directly" $
+    checkObservation AntiPattern.plustan09 118 3 50
+
+  it "PLU-STAN-09: valueOf compared via let bindings" $
+    checkObservation AntiPattern.plustan09 131 6 39
+
+  it "PLU-STAN-09: valueOf compared with literal on the left" $
+    checkObservation AntiPattern.plustan09 144 3 50
+
+  it "PLU-STAN-09: valueOf compared via prefix (==)" $
+    checkObservation AntiPattern.plustan09 155 3 54
+
+  it "PLU-STAN-09: valueOf compared via section (== 5000)" $
+    checkObservation AntiPattern.plustan09 166 3 54


### PR DESCRIPTION
Introduce the following new rules:

| PLU-STAN-05 | Usage of higher-order helpers like 'all', 'any', and 'find' in on-chain code | Performance | Medium    |
| PLU-STAN-06 | Multiple list traversals in on-chain code | Performance | Medium    |
| PLU-STAN-07 | Guard syntax in on-chain code | Performance | Medium    |
| PLU-STAN-08 | Non-strict let binding used multiple times | Performance | Medium    |
| PLU-STAN-09 | valueOf in boolean conditions | Security    | Medium    |