### PR TITLE
feat: plu-stan rules for outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ cabal test
 cabal run stan-test
   ```
 
+### Plu-Stan CLI (JSON + Onchain modules)
+
+`plustan` now supports machine-readable output for editor integrations.
+
+```bash
+# list onchain modules (detected via annotation)
+plustan list-onchain --json
+
+# run on full codebase
+plustan analyze --json
+
+# run on one onchain module
+plustan analyze --json --module Target.PlutusTx
+```
+
+The repository also includes a standalone VS Code/Cursor extension scaffold in `vscode-plustan/`.
+
 ### Haskell language server integration
 
 There is a fork of haskell language server that uses plu-stan as the stan plugin alternative.

--- a/app/PluStan.hs
+++ b/app/PluStan.hs
@@ -1,21 +1,26 @@
-  module Main (main) where
+module Main (main) where
 
 import Colourista (errorMessage, infoMessage, successMessage, warningMessage)
 import Control.Exception (SomeException, handle, try)
 import Control.Monad (forM, when)
 import Control.Monad.IO.Class (liftIO)
-import Data.List (isPrefixOf)
+import Data.Aeson.Micro (ToJSON (..), encode, object, (.=))
+import Data.Foldable (toList, traverse_)
+import Data.List (isPrefixOf, sortOn)
 import Data.Maybe (catMaybes, mapMaybe)
 import GHC.IO.Encoding (setLocaleEncoding, utf8)
 import System.Directory (doesDirectoryExist, getCurrentDirectory, listDirectory, setCurrentDirectory)
 import System.Directory (findExecutable)
 import System.Environment (getArgs)
-import System.Exit (exitFailure)
+import System.Exit (ExitCode (..), exitFailure, exitWith)
 import System.FilePath ((</>), takeExtension, takeFileName)
-import System.Process (callProcess)
 import System.Info (compilerVersion)
+import System.IO (stderr)
+import System.Process (CreateProcess (std_err, std_out), StdStream (UseHandle), callProcess,
+                       createProcess, proc, waitForProcess)
 import Data.Version (showVersion)
 import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Trial (withTag, whenResult_)
 
 import Stan (getAnalysis)
@@ -26,25 +31,26 @@ import Stan.Cabal (usedCabalFiles)
 import Stan.Cli (StanArgs (..))
 import Stan.Config (Check (..), CheckFilter (..), CheckType (..), Config, ConfigP (..),
                     PartialConfig, Scope (..), finaliseConfig)
+import Stan.Core.ModuleName (ModuleName (..), fromGhcModule)
 import Stan.EnvVars (envVarsToText, getEnvVars)
+import Stan.FileInfo (FileInfo (..))
 import Stan.Hie (readHieFiles)
 import Stan.Hie.Compat (HieFile (..))
 import Stan.Info (ProjectInfo (..), StanEnv (..))
 import Stan.Inspection (Inspection (..))
 import Stan.Inspection.All (getInspectionById)
-import Stan.FileInfo (FileInfo (..))
 import Stan.Observation (Observation (..))
 import Stan.Report (generateReport)
 import Stan.Report.Settings (OutputSettings (..), ToggleSolution (..), Verbosity (..))
 import Stan.Severity (Severity (..))
 
-import qualified Stan.Category as Category
-import qualified Slist as Slist
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
+import qualified Stan.Category as Category
+import qualified Slist as Slist
 
 import GHC (getSessionDynFlags, runGhc, setSessionDynFlags)
 import GHC.Driver.Session (targetProfile)
@@ -62,32 +68,146 @@ main :: IO ()
 main = setLocaleEncoding utf8 >> runPluStan
 
 runPluStan :: IO ()
-runPluStan =
+runPluStan = do
+  args <- getArgs
+  case parsePluStanCommand args of
+    Left err -> do
+      if err == "help"
+        then Text.putStrLn usage
+        else do
+          errorMessage (Text.pack err)
+          Text.putStrLn usage
+          exitFailure
+    Right command -> case command of
+      CommandAnalyze analyzeArgs -> runAnalyze analyzeArgs
+      CommandListOnchain listArgs -> runListOnchain listArgs
+
+data PluStanCommand
+  = CommandAnalyze AnalyzeArgs
+  | CommandListOnchain ListOnchainArgs
+
+data AnalyzeArgs = AnalyzeArgs
+  { analyzeReport :: Bool
+  , analyzeBrowse :: Bool
+  , analyzeProjectDir :: Maybe FilePath
+  , analyzeHieDir :: FilePath
+  , analyzeJson :: Bool
+  , analyzeModule :: Maybe Text
+  }
+
+data ListOnchainArgs = ListOnchainArgs
+  { listOnchainProjectDir :: Maybe FilePath
+  , listOnchainHieDir :: FilePath
+  , listOnchainJson :: Bool
+  }
+
+data OnchainAnnotationSource
+  = AnnotationHi
+  | AnnotationSource
+  | AnnotationBoth
+  deriving stock (Show, Eq)
+
+instance ToJSON OnchainAnnotationSource where
+  toJSON = \case
+    AnnotationHi -> toJSON ("hi" :: Text)
+    AnnotationSource -> toJSON ("source" :: Text)
+    AnnotationBoth -> toJSON ("both" :: Text)
+
+data OnchainModule = OnchainModule
+  { onchainModuleName :: ModuleName
+  , onchainModuleFile :: FilePath
+  , onchainAnnotationSource :: OnchainAnnotationSource
+  } deriving stock (Show, Eq)
+
+instance ToJSON OnchainModule where
+  toJSON OnchainModule{..} = object
+    [ "moduleName" .= onchainModuleName
+    , "file" .= Text.pack onchainModuleFile
+    , "annotationSource" .= onchainAnnotationSource
+    ]
+
+data ListOnchainJsonPayload = ListOnchainJsonPayload
+  { listPayloadVersion :: Int
+  , listPayloadWorkspaceRoot :: FilePath
+  , listPayloadHieDir :: FilePath
+  , listPayloadModules :: [OnchainModule]
+  }
+
+instance ToJSON ListOnchainJsonPayload where
+  toJSON ListOnchainJsonPayload{..} = object
+    [ "version" .= listPayloadVersion
+    , "workspaceRoot" .= Text.pack listPayloadWorkspaceRoot
+    , "hieDir" .= Text.pack listPayloadHieDir
+    , "modules" .= listPayloadModules
+    ]
+
+data AnalyzeJsonPayload = AnalyzeJsonPayload
+  { analyzePayloadVersion :: Int
+  , analyzePayloadRunScope :: Text
+  , analyzePayloadTargetModule :: Maybe ModuleName
+  , analyzePayloadInspections :: [Inspection]
+  , analyzePayloadAnalysis :: Analysis
+  }
+
+instance ToJSON AnalyzeJsonPayload where
+  toJSON AnalyzeJsonPayload{..} = object
+    [ "version" .= analyzePayloadVersion
+    , "runScope" .= analyzePayloadRunScope
+    , "targetModule" .= analyzePayloadTargetModule
+    , "inspections" .= analyzePayloadInspections
+    , "analysis" .= analyzePayloadAnalysis
+    ]
+
+runAnalyze :: AnalyzeArgs -> IO ()
+runAnalyze AnalyzeArgs{..} =
   whenResult_ (finaliseConfig pluStanConfig) $ \warnings config -> do
-    cli <- parsePluStanArgs
-    case plustanProjectDir cli of
-      Nothing -> pure ()
-      Just dir -> do
-        exists <- doesDirectoryExist dir
-        if exists
-          then setCurrentDirectory dir
-          else do
-            errorMessage . Text.pack $ "Project directory does not exist: " <> dir
-            exitFailure
-    let hieDir = plustanHieDir cli
-    ensureHieFiles hieDir
-    hieFiles <- readHieFilesOrRebuild hieDir
+    let notJson = not analyzeJson
+    enterProjectDir analyzeProjectDir notJson
+    let hieDir = analyzeHieDir
+    ensureFreshHieFiles hieDir notJson
+    hieFiles <- readHieFilesOrRebuild hieDir notJson
     when (null hieFiles) $ do
-      warningMessage "No .hie files found after build. Ensure the project is compiled with -fwrite-ide-info and -hiedir=.hie."
+      reportWarning notJson "No .hie files found after build. Ensure the project is compiled with -fwrite-ide-info and -hiedir=.hie."
       exitFailure
-    analysis <- getAnalysis (stanArgs hieDir) True config hieFiles >>= removeOffchain hieDir hieFiles
+
+    onchainModules <- discoverOnchainModules hieDir hieFiles
+    targetModule <- resolveTargetModule analyzeModule onchainModules notJson
+    let targetFiles = maybe Set.empty (Set.singleton . onchainModuleFile) targetModule
+    let filteredHieFiles =
+          if Set.null targetFiles
+            then hieFiles
+            else filter (\HieFile{..} -> Set.member hie_hs_file targetFiles) hieFiles
+
+    when (null filteredHieFiles) $ do
+      let moduleLabel = maybe "<unknown>" (Text.unpack . unModuleName . onchainModuleName) targetModule
+      reportError notJson $ "No HIE module found for target module: " <> Text.pack moduleLabel
+      exitFailure
+
+    analysis <- getAnalysis (stanArgs hieDir) notJson config filteredHieFiles
+      >>= pure . filterAnalysisToContracts (Set.fromList $ map onchainModuleFile onchainModules)
+      >>= pure . maybe id (limitAnalysisToTarget . onchainModuleFile) targetModule
+
     let observations = analysisObservations analysis
-    if null observations
-      then successMessage "All clean! Plu-Stan did not find any observations at the moment."
-      else warningMessage "Plu-Stan found the following observations:\n"
-    Text.putStrLn $ prettyShowAnalysis analysis outputSettings
-    when (plustanReport cli) $
-      generatePluStanReport cli config warnings hieFiles analysis
+    let usedInspections = sortOn inspectionId $ map getInspectionById (toList $ analysisInspections analysis)
+
+    if analyzeJson
+      then do
+        putJson AnalyzeJsonPayload
+          { analyzePayloadVersion = 1
+          , analyzePayloadRunScope = maybe "all" (const "module") targetModule
+          , analyzePayloadTargetModule = onchainModuleName <$> targetModule
+          , analyzePayloadInspections = usedInspections
+          , analyzePayloadAnalysis = analysis
+          }
+      else do
+        if null observations
+          then successMessage "All clean! Plu-Stan did not find any observations at the moment."
+          else warningMessage "Plu-Stan found the following observations:\n"
+        Text.putStrLn $ prettyShowAnalysis analysis outputSettings
+
+    when (analyzeReport && not analyzeJson) $
+      generatePluStanReport AnalyzeArgs{..} config warnings filteredHieFiles analysis
+
     when (any ((>= Error) . getObservationSeverity) observations) exitFailure
   where
     outputSettings :: OutputSettings
@@ -111,112 +231,224 @@ runPluStan =
     getObservationSeverity :: Observation -> Severity
     getObservationSeverity = inspectionSeverity . getInspectionById . observationInspectionId
 
-generatePluStanReport
-  :: PluStanArgs
-  -> Config
-  -> [Text]
-  -> [HieFile]
-  -> Analysis
-  -> IO ()
-generatePluStanReport PluStanArgs{..} config warnings hieFiles analysis = do
-  env <- getEnvVars
-  seCliArgs <- getArgs
-  piName <- takeFileName <$> getCurrentDirectory
-  piCabalFiles <- usedCabalFiles []
-  let piHieDir = plustanHieDir
-  let piFileNumber = length hieFiles
-  let stanEnv = StanEnv
-        { seEnvVars = envVarsToText env
-        , seTomlFiles = []
-        , ..
-        }
-  generateReport analysis config warnings stanEnv ProjectInfo{..}
-  infoMessage "Report is generated here -> stan.html"
-  when plustanBrowse $ openBrowser "stan.html"
+runListOnchain :: ListOnchainArgs -> IO ()
+runListOnchain ListOnchainArgs{..} = do
+  let notJson = not listOnchainJson
+  enterProjectDir listOnchainProjectDir notJson
+  let hieDir = listOnchainHieDir
+  ensureFreshHieFiles hieDir notJson
+  hieFiles <- readHieFilesOrRebuild hieDir notJson
+  modules <- discoverOnchainModules hieDir hieFiles
+  currentDir <- getCurrentDirectory
+  if listOnchainJson
+    then putJson ListOnchainJsonPayload
+      { listPayloadVersion = 1
+      , listPayloadWorkspaceRoot = currentDir
+      , listPayloadHieDir = hieDir
+      , listPayloadModules = modules
+      }
+    else printOnchainModules modules
 
-data PluStanArgs = PluStanArgs
-  { plustanReport :: Bool
-  , plustanBrowse :: Bool
-  , plustanProjectDir :: Maybe FilePath
-  , plustanHieDir :: FilePath
-  }
-
-parsePluStanArgs :: IO PluStanArgs
-parsePluStanArgs = do
-  args <- getArgs
-  case go defaultArgs args of
-    Left err -> do
-      errorMessage $ Text.pack err
-      Text.putStrLn usage
-      exitFailure
-    Right parsed -> pure parsed
+printOnchainModules :: [OnchainModule] -> IO ()
+printOnchainModules modules =
+  if null modules
+    then infoMessage "No onchain modules were found."
+    else traverse_ printLine modules
   where
-    defaultArgs = PluStanArgs False False Nothing ".hie"
-    usage = Text.unlines
-      [ "Usage: plustan [--report] [--browse] [--project DIR] [--hiedir DIR] [PROJECT_DIR]"
-      , "  --report      Generate stan.html report"
-      , "  --browse      Open report in browser (implies --report)"
-      , "  --project DIR Change into project DIR before running (same as positional PROJECT_DIR)"
-      , "  --hiedir DIR  Directory with .hie/.hi files (default: .hie)"
-      ]
+    printLine :: OnchainModule -> IO ()
+    printLine OnchainModule{..} =
+      Text.putStrLn $ unModuleName onchainModuleName <> " -> " <> Text.pack onchainModuleFile
 
-    go :: PluStanArgs -> [String] -> Either String PluStanArgs
+usage :: Text
+usage = Text.unlines
+  [ "Usage:"
+  , "  plustan [--report] [--browse] [--json] [--module MODULE] [--project DIR] [--hiedir DIR] [PROJECT_DIR]"
+  , "  plustan analyze [--report] [--browse] [--json] [--module MODULE] [--project DIR] [--hiedir DIR]"
+  , "  plustan list-onchain [--json] [--project DIR] [--hiedir DIR]"
+  , ""
+  , "Options:"
+  , "  --report        Generate stan.html report (analyze only)"
+  , "  --browse        Open report in browser (implies --report)"
+  , "  --json          Output machine-readable JSON"
+  , "  --module NAME   Analyze a single onchain module by GHC module name"
+  , "  --project DIR   Change into project DIR before running"
+  , "  --hiedir DIR    Directory with .hie/.hi files (default: .hie)"
+  ]
+
+parsePluStanCommand :: [String] -> Either String PluStanCommand
+parsePluStanCommand = \case
+  [] -> CommandAnalyze <$> parseAnalyzeArgs True defaultAnalyzeArgs []
+  "analyze":rest -> CommandAnalyze <$> parseAnalyzeArgs False defaultAnalyzeArgs rest
+  "list-onchain":rest -> CommandListOnchain <$> parseListOnchainArgs defaultListOnchainArgs rest
+  "help":_ -> Left "help"
+  "--help":_ -> Left "help"
+  "-h":_ -> Left "help"
+  args -> CommandAnalyze <$> parseAnalyzeArgs True defaultAnalyzeArgs args
+
+parseAnalyzeArgs :: Bool -> AnalyzeArgs -> [String] -> Either String AnalyzeArgs
+parseAnalyzeArgs allowLegacyPositional = go
+  where
+    go :: AnalyzeArgs -> [String] -> Either String AnalyzeArgs
     go acc [] = Right acc
-    go acc ("--report":xs) = go acc { plustanReport = True } xs
-    go acc ("--browse":xs) = go acc { plustanReport = True, plustanBrowse = True } xs
-    go acc ("--project":dir:xs) = go acc { plustanProjectDir = Just dir } xs
-    go acc ("--hiedir":dir:xs) = go acc { plustanHieDir = dir } xs
+    go acc ("--report":xs) = go acc { analyzeReport = True } xs
+    go acc ("--browse":xs) = go acc { analyzeReport = True, analyzeBrowse = True } xs
+    go acc ("--json":xs) = go acc { analyzeJson = True } xs
+    go acc ("--project":dir:xs) = go acc { analyzeProjectDir = Just dir } xs
+    go acc ("--hiedir":dir:xs) = go acc { analyzeHieDir = dir } xs
+    go acc ("--module":modName:xs) = go acc { analyzeModule = Just (Text.pack modName) } xs
     go acc (arg:xs)
       | "--project=" `isPrefixOf` arg =
           let prefix = "--project=" :: String
-          in go acc { plustanProjectDir = Just (drop (length prefix) arg) } xs
+          in go acc { analyzeProjectDir = Just (drop (length prefix) arg) } xs
       | "--hiedir=" `isPrefixOf` arg =
           let prefix = "--hiedir=" :: String
-          in go acc { plustanHieDir = drop (length prefix) arg } xs
+          in go acc { analyzeHieDir = drop (length prefix) arg } xs
+      | "--module=" `isPrefixOf` arg =
+          let prefix = "--module=" :: String
+          in go acc { analyzeModule = Just (Text.pack $ drop (length prefix) arg) } xs
+      | "-" `isPrefixOf` arg = Left ("Unknown argument: " <> arg)
+      | allowLegacyPositional =
+          case analyzeProjectDir acc of
+            Nothing -> go acc { analyzeProjectDir = Just arg } xs
+            Just _ -> Left ("Unexpected extra positional argument: " <> arg)
+      | otherwise = Left ("Unexpected positional argument: " <> arg)
+
+defaultAnalyzeArgs :: AnalyzeArgs
+defaultAnalyzeArgs = AnalyzeArgs
+  { analyzeReport = False
+  , analyzeBrowse = False
+  , analyzeProjectDir = Nothing
+  , analyzeHieDir = ".hie"
+  , analyzeJson = False
+  , analyzeModule = Nothing
+  }
+
+parseListOnchainArgs :: ListOnchainArgs -> [String] -> Either String ListOnchainArgs
+parseListOnchainArgs = go
+  where
+    go :: ListOnchainArgs -> [String] -> Either String ListOnchainArgs
+    go acc [] = Right acc
+    go acc ("--json":xs) = go acc { listOnchainJson = True } xs
+    go acc ("--project":dir:xs) = go acc { listOnchainProjectDir = Just dir } xs
+    go acc ("--hiedir":dir:xs) = go acc { listOnchainHieDir = dir } xs
+    go acc (arg:xs)
+      | "--project=" `isPrefixOf` arg =
+          let prefix = "--project=" :: String
+          in go acc { listOnchainProjectDir = Just (drop (length prefix) arg) } xs
+      | "--hiedir=" `isPrefixOf` arg =
+          let prefix = "--hiedir=" :: String
+          in go acc { listOnchainHieDir = drop (length prefix) arg } xs
       | "-" `isPrefixOf` arg = Left ("Unknown argument: " <> arg)
       | otherwise =
-          case plustanProjectDir acc of
-            Nothing -> go acc { plustanProjectDir = Just arg } xs
+          case listOnchainProjectDir acc of
+            Nothing -> go acc { listOnchainProjectDir = Just arg } xs
             Just _ -> Left ("Unexpected extra positional argument: " <> arg)
 
-ensureHieFiles :: FilePath -> IO ()
-ensureHieFiles hieDir = do
+defaultListOnchainArgs :: ListOnchainArgs
+defaultListOnchainArgs = ListOnchainArgs
+  { listOnchainProjectDir = Nothing
+  , listOnchainHieDir = ".hie"
+  , listOnchainJson = False
+  }
+
+resolveTargetModule :: Maybe Text -> [OnchainModule] -> Bool -> IO (Maybe OnchainModule)
+resolveTargetModule Nothing _ _ = pure Nothing
+resolveTargetModule (Just moduleName) modules notJson =
+  case filter ((== moduleName) . unModuleName . onchainModuleName) modules of
+    (mod':_) -> pure (Just mod')
+    [] -> do
+      let candidates = map (unModuleName . onchainModuleName) modules
+      let hint =
+            if null candidates
+              then "No onchain modules were discovered in this project."
+              else "Known onchain modules: " <> Text.intercalate ", " candidates
+      reportError notJson $ "Unknown onchain module: " <> moduleName
+      reportError notJson hint
+      exitFailure
+
+putJson :: ToJSON a => a -> IO ()
+putJson = LBS8.putStrLn . encode
+
+enterProjectDir :: Maybe FilePath -> Bool -> IO ()
+enterProjectDir Nothing _ = pure ()
+enterProjectDir (Just dir) notJson = do
+  exists <- doesDirectoryExist dir
+  if exists
+    then setCurrentDirectory dir
+    else do
+      reportError notJson $ "Project directory does not exist: " <> Text.pack dir
+      exitFailure
+
+reportError :: Bool -> Text -> IO ()
+reportError notJson msg =
+  if notJson
+    then errorMessage msg
+    else Text.hPutStrLn stderr msg
+
+reportWarning :: Bool -> Text -> IO ()
+reportWarning notJson msg =
+  if notJson
+    then warningMessage msg
+    else Text.hPutStrLn stderr msg
+
+ensureFreshHieFiles :: FilePath -> Bool -> IO ()
+ensureFreshHieFiles hieDir notJson = do
   hasHie <- hasFilesWithExt hieDir ".hie"
   hasHi <- hasFilesWithExt hieDir ".hi"
-  when (not (hasHie && hasHi)) $ do
-    infoMessage "Missing .hie/.hi files. Running cabal build to generate artifacts..."
-    buildHieFiles hieDir
+  if not (hasHie && hasHi)
+    then do
+      when notJson $ infoMessage "Missing .hie/.hi files. Running full cabal build to generate artifacts..."
+      buildHieFiles hieDir notJson True
+    else do
+      when notJson $ infoMessage "Refreshing .hie/.hi files for changed sources..."
+      buildHieFiles hieDir notJson False
 
-readHieFilesOrRebuild :: FilePath -> IO [HieFile]
-readHieFilesOrRebuild hieDir = do
+readHieFilesOrRebuild :: FilePath -> Bool -> IO [HieFile]
+readHieFilesOrRebuild hieDir notJson = do
   res <- try (readHieFiles hieDir)
   case res of
     Right hieFiles -> pure hieFiles
     Left (_ :: SomeException) -> do
-      warningMessage "Failed to read .hie files (possibly built by a different GHC). Rebuilding..."
-      buildHieFiles hieDir
+      reportWarning notJson "Failed to read .hie files (possibly built by a different GHC). Rebuilding..."
+      buildHieFiles hieDir notJson True
       readHieFiles hieDir
 
-buildHieFiles :: FilePath -> IO ()
-buildHieFiles hieDir = do
+buildHieFiles :: FilePath -> Bool -> Bool -> IO ()
+buildHieFiles hieDir notJson forceRecomp = do
   let ghcVer = "ghc-" <> showVersion compilerVersion
   ghc <- maybe "ghc" id <$> findExecutable ghcVer
-  callProcess "cabal"
-    [ "build"
-    , "all"
-    , "--disable-tests"
-    , "-w"
-    , ghc
-    , "--ghc-options=-fforce-recomp"
-    , "--ghc-options=-fwrite-ide-info"
-    , "--ghc-options=-hiedir=" <> hieDir
-    , "--ghc-options=-hidir=" <> hieDir
-    ]
+  let forceRecompArg =
+        if forceRecomp
+          then ["--ghc-options=-fforce-recomp"]
+          else []
+  let buildArgs =
+        [ "build"
+        , "all"
+        , "--disable-tests"
+        , "-w"
+        , ghc
+        ]
+        <> forceRecompArg
+        <>
+        [ "--ghc-options=-fwrite-ide-info"
+        , "--ghc-options=-hiedir=" <> hieDir
+        , "--ghc-options=-hidir=" <> hieDir
+        ]
+  if notJson
+    then callProcess "cabal" buildArgs
+    else do
+      (_, _, _, processHandle) <- createProcess (proc "cabal" buildArgs)
+        { std_out = UseHandle stderr
+        , std_err = UseHandle stderr
+        }
+      waitForProcess processHandle >>= \case
+        ExitSuccess -> pure ()
+        ExitFailure code -> exitWith (ExitFailure code)
 
 hasFilesWithExt :: FilePath -> String -> IO Bool
 hasFilesWithExt dir ext = do
   files <- listFilesWithExt dir ext
-  pure (not (null files))
+  pure (not $ null files)
 
 listFilesWithExt :: FilePath -> String -> IO [FilePath]
 listFilesWithExt dir ext = do
@@ -254,51 +486,103 @@ hasOnchainAnnotation iface = any isOnchainAnn (mi_anns iface)
           Nothing -> False
         _ -> False
 
-onchainFiles :: FilePath -> [HieFile] -> IO (Set.Set FilePath)
-onchainFiles hieDir hieFiles =
-  handle @SomeException (\_ -> pure Set.empty) $ runGhc (Just libdir) $ do
+discoverOnchainModules :: FilePath -> [HieFile] -> IO [OnchainModule]
+discoverOnchainModules hieDir hieFiles =
+  handle @SomeException (\_ -> pure []) $ runGhc (Just libdir) $ do
     dflags <- getSessionDynFlags
     _ <- setSessionDynFlags dflags
     hiFiles <- liftIO $ listFilesWithExt hieDir ".hi"
     nameCache <- liftIO $ initNameCache 'z' []
     let profile = targetProfile dflags
+
     let moduleToFile = Map.fromList [(hie_module, hie_hs_file) | HieFile{..} <- hieFiles]
-    annotatedModules <- liftIO $ fmap catMaybes $ forM hiFiles $ \hiPath -> do
+    annotatedFromHi <- liftIO $ fmap catMaybes $ forM hiFiles $ \hiPath -> do
       iface <- readModIface profile nameCache hiPath
-      pure $ iface >>= \modIface -> if hasOnchainAnnotation modIface
-        then Just (mi_module modIface)
-        else Nothing
-    let fromHi = Set.fromList $ mapMaybe (`Map.lookup` moduleToFile) annotatedModules
-    let fromHie =
-          Set.fromList
-            [ hie_hs_file
-            | HieFile{..} <- hieFiles
-            , hasOnchainAnnotationInSource hie_hs_src
-            ]
-    pure $ Set.union fromHi fromHie
+      pure $ iface >>= \modIface ->
+        if hasOnchainAnnotation modIface
+          then Just (mi_module modIface)
+          else Nothing
+
+    let fromHiSet = Set.fromList annotatedFromHi
+    let fromSourceSet = Set.fromList
+          [ hie_module
+          | HieFile{..} <- hieFiles
+          , hasOnchainAnnotationInSource hie_hs_src
+          ]
+    let allOnchainModules = Set.toList (Set.union fromHiSet fromSourceSet)
+
+    pure $ sortOn (unModuleName . onchainModuleName) $
+      mapMaybe (toOnchainModule moduleToFile fromHiSet fromSourceSet) allOnchainModules
+  where
+    toOnchainModule moduleToFile fromHiSet fromSourceSet ghcModule = do
+      filePath <- Map.lookup ghcModule moduleToFile
+      let inHi = Set.member ghcModule fromHiSet
+      let inSource = Set.member ghcModule fromSourceSet
+      annotationSource <- case (inHi, inSource) of
+        (True, True) -> Just AnnotationBoth
+        (True, False) -> Just AnnotationHi
+        (False, True) -> Just AnnotationSource
+        (False, False) -> Nothing
+      pure OnchainModule
+        { onchainModuleName = fromGhcModule ghcModule
+        , onchainModuleFile = filePath
+        , onchainAnnotationSource = annotationSource
+        }
 
 hasOnchainAnnotationInSource :: BS8.ByteString -> Bool
 hasOnchainAnnotationInSource src =
-  "ANN module" `BS8.isInfixOf` src
-    && "onchain-contract" `BS8.isInfixOf` src
+  any lineLooksLikeOnchainAnnotation (BS8.lines src)
+  where
+    lineLooksLikeOnchainAnnotation :: BS8.ByteString -> Bool
+    lineLooksLikeOnchainAnnotation line =
+      "{-# ANN module" `BS8.isInfixOf` line
+        && "onchain-contract" `BS8.isInfixOf` line
 
-isOnchainObservations :: Set.Set FilePath -> Observation -> Bool
-isOnchainObservations files obs = Set.member (observationFile obs) files
+isOnchainObservation :: Set.Set FilePath -> Observation -> Bool
+isOnchainObservation files obs = Set.member (observationFile obs) files
 
 onchainCondition :: Set.Set FilePath -> Observation -> Bool
-onchainCondition contracts obs = not (isPlinthObservation obs) || isOnchainObservations contracts obs
+onchainCondition contracts obs = not (isPlinthObservation obs) || isOnchainObservation contracts obs
 
 filterForOnchain :: Set.Set FilePath -> FileInfo -> FileInfo
-filterForOnchain contracts info@FileInfo{..}= info {
-  fileInfoObservations = Slist.filter (onchainCondition contracts) fileInfoObservations }
+filterForOnchain contracts info@FileInfo{..} = info
+  { fileInfoObservations = Slist.filter (onchainCondition contracts) fileInfoObservations
+  }
 
-removeOffchain :: FilePath -> [HieFile] -> Analysis -> IO Analysis
-removeOffchain hieDir hieFiles analysis = do
-  contracts <- onchainFiles hieDir hieFiles
-  pure analysis {
-          analysisObservations = Slist.filter (onchainCondition contracts) (analysisObservations analysis)
-        , analysisFileMap = fmap (filterForOnchain contracts) (analysisFileMap analysis)
-      }
+filterAnalysisToContracts :: Set.Set FilePath -> Analysis -> Analysis
+filterAnalysisToContracts contracts analysis = analysis
+  { analysisObservations = Slist.filter (onchainCondition contracts) (analysisObservations analysis)
+  , analysisFileMap = fmap (filterForOnchain contracts) (analysisFileMap analysis)
+  }
+
+limitAnalysisToTarget :: FilePath -> Analysis -> Analysis
+limitAnalysisToTarget targetFile analysis = analysis
+  { analysisObservations = Slist.filter ((== targetFile) . observationFile) (analysisObservations analysis)
+  , analysisFileMap = Map.filterWithKey (\filePath _ -> filePath == targetFile) (analysisFileMap analysis)
+  }
+
+generatePluStanReport
+  :: AnalyzeArgs
+  -> Config
+  -> [Text]
+  -> [HieFile]
+  -> Analysis
+  -> IO ()
+generatePluStanReport AnalyzeArgs{..} config warnings hieFiles analysis = do
+  env <- getEnvVars
+  seCliArgs <- getArgs
+  piName <- takeFileName <$> getCurrentDirectory
+  piCabalFiles <- usedCabalFiles []
+  let piHieDir = analyzeHieDir
+  let piFileNumber = length hieFiles
+  let stanEnv = StanEnv
+        { seEnvVars = envVarsToText env
+        , seTomlFiles = []
+        , ..
+        }
+  generateReport analysis config warnings stanEnv ProjectInfo{..}
+  infoMessage "Report is generated here -> stan.html"
+  when analyzeBrowse $ openBrowser "stan.html"
 
 pluStanConfig :: PartialConfig
 pluStanConfig = ConfigP

--- a/src/Stan/Analysis/Analyser.hs
+++ b/src/Stan/Analysis/Analyser.hs
@@ -1547,11 +1547,8 @@ analyseUnsafeFromBuiltinDataInHashComparison insId hie curNode =
               || (operandFromUnsafe rhsNode && typeMatchesHash lhs)
               || (comparisonMentionsUnsafeBinding node && (typeMatchesHash lhs || typeMatchesHash rhsNode))
               || (comparisonLineMentionsUnsafeBinding node && (typeMatchesHash lhs || typeMatchesHash rhsNode)) ->
-                -- If we've matched a comparison expression, don't recurse into it;
-                -- the HIE tree can contain nested nodes with the same span.
                 S.one $ nodeSpan node
-        _ ->
-            foldMap matchNode (nodeChildren node)
+        _ -> mempty
 
     -- Check if operand either:
     -- 1. Directly contains unsafeFromBuiltinData, OR
@@ -2900,13 +2897,27 @@ analyseMissingTxOutFieldCheck missingField insId hie curNode =
 
     findAnchor :: HieAST TypeIndex -> Maybe RealSrcSpan
     findAnchor n@Node{nodeSpan = span', nodeChildren = children}
-        | isOneLineSpan span' && nodeHasAnyOccName allFieldTokens n = Just span'
+        | isOneLineSpan span'
+            && nodeHasAnyOccName allFieldTokens n
+            && not (spanLooksLikeBinding span') = Just span'
         | otherwise = asum (map findAnchor children)
 
     isOneLineSpan :: RealSrcSpan -> Bool
     isOneLineSpan span' =
         srcSpanStartLine span' == srcSpanEndLine span'
 
+    spanLooksLikeBinding :: RealSrcSpan -> Bool
+    spanLooksLikeBinding span' = case srcLineAt (srcSpanStartLine span') of
+        Nothing -> False
+        Just line -> case parseBindingLhs line of
+            Nothing -> False
+            Just lhsOcc -> lhsOcc `elem`
+                [ "txOutAddress"
+                , "txOutValue"
+                , "txOutDatum"
+                , "txOutReferenceScript"
+                , "referenceScript"
+                ]
     shouldFlagNode :: HieAST TypeIndex -> Bool
     shouldFlagNode node =
         let txOutUsageCandidates = usageCandidates node
@@ -2919,13 +2930,19 @@ analyseMissingTxOutFieldCheck missingField insId hie curNode =
         [] -> [detectTxOutFieldUsage node]
         _ ->
             let varGroups = txOutAliasGroups txOutVars (nodeSpan node)
+                allowGlobalAliasFallback = length varGroups == 1
                 groupedUsage =
                     map
-                        (\varGroup -> detectTxOutFieldUsageForVars varGroup node)
+                        (\varGroup ->
+                            detectTxOutFieldUsageForVars
+                                allowGlobalAliasFallback
+                                varGroup
+                                node
+                        )
                         varGroups
                 fallbackGeneric =
                     [ detectTxOutFieldUsage node
-                    | length varGroups == 1
+                    | allowGlobalAliasFallback
                     ]
             in groupedUsage <> fallbackGeneric
       where
@@ -2944,18 +2961,41 @@ analyseMissingTxOutFieldCheck missingField insId hie curNode =
         , txOutFieldReferenceChecked = subtreeHasAnyTxOutFieldToken referenceTokens node
         }
 
-    detectTxOutFieldUsageForVars :: Set Name -> HieAST TypeIndex -> TxOutFieldUsage
-    detectTxOutFieldUsageForVars varGroup node =
+    detectTxOutFieldUsageForVars :: Bool -> Set Name -> HieAST TypeIndex -> TxOutFieldUsage
+    detectTxOutFieldUsageForVars allowGlobalAliasFallback varGroup node =
         let span' = nodeSpan node
+            aliasOccsByField =
+                let scopedAliasOccs = spanRecordFieldAliasesForVars varGroup span'
+                in if Map.null scopedAliasOccs && allowGlobalAliasFallback
+                    then spanRecordFieldAliasesForVars Set.empty span'
+                    else scopedAliasOccs
+            addressAliasOccs = lookupFieldAliasOccs fieldKeyAddress aliasOccsByField
+            valueAliasOccs = lookupFieldAliasOccs fieldKeyValue aliasOccsByField
+            datumAliasOccs = lookupFieldAliasOccs fieldKeyDatum aliasOccsByField
+            referenceAliasOccs = lookupFieldAliasOccs fieldKeyReference aliasOccsByField
+            addressCheckedByAliases =
+                spanMentionsAnyFieldTokenForOccs addressTokens addressAliasOccs span'
+                    || spanMentionsAddressEqForOccs addressAliasOccs span'
             addressEqImpliesStaking =
                 spanMentionsAddressEqForVars varGroup span'
+                    || spanMentionsAddressEqForOccs addressAliasOccs span'
         in TxOutFieldUsage
-        { txOutFieldAddressChecked = spanMentionsAnyFieldTokenForVars addressTokens varGroup span'
+        { txOutFieldAddressChecked =
+            spanMentionsAnyFieldTokenForVars addressTokens varGroup span'
+                || addressCheckedByAliases
         , txOutFieldStakingChecked =
-            spanMentionsAnyFieldTokenForVars stakingTokens varGroup span' || addressEqImpliesStaking
-        , txOutFieldValueChecked = spanMentionsAnyFieldTokenForVars valueTokens varGroup span'
-        , txOutFieldDatumChecked = spanMentionsAnyFieldTokenForVars datumTokens varGroup span'
-        , txOutFieldReferenceChecked = spanMentionsAnyFieldTokenForVars referenceTokens varGroup span'
+            spanMentionsAnyFieldTokenForVars stakingTokens varGroup span'
+                || spanMentionsAnyFieldTokenForOccs stakingTokens addressAliasOccs span'
+                || addressEqImpliesStaking
+        , txOutFieldValueChecked =
+            spanMentionsAnyFieldTokenForVars valueTokens varGroup span'
+                || spanMentionsAnyFieldTokenForOccs valueTokens valueAliasOccs span'
+        , txOutFieldDatumChecked =
+            spanMentionsAnyFieldTokenForVars datumTokens varGroup span'
+                || spanMentionsAnyFieldTokenForOccs datumTokens datumAliasOccs span'
+        , txOutFieldReferenceChecked =
+            spanMentionsAnyFieldTokenForVars referenceTokens varGroup span'
+                || spanMentionsAnyFieldTokenForOccs referenceTokens referenceAliasOccs span'
         }
 
     collectTxOutVariableNames :: HieAST TypeIndex -> Set Name
@@ -3014,6 +3054,125 @@ analyseMissingTxOutFieldCheck missingField insId hie curNode =
         guard (BS8.all isSpace rhsRest)
         pure (lhsOcc, rhsOcc)
 
+    fieldKeyAddress, fieldKeyValue, fieldKeyDatum, fieldKeyReference :: String
+    fieldKeyAddress = "address"
+    fieldKeyValue = "value"
+    fieldKeyDatum = "datum"
+    fieldKeyReference = "reference"
+
+    lookupFieldAliasOccs :: String -> Map String (Set String) -> Set String
+    lookupFieldAliasOccs fieldKey aliases =
+        Map.findWithDefault Set.empty fieldKey aliases
+
+    mergeFieldAliasMaps :: Map String (Set String) -> Map String (Set String) -> Map String (Set String)
+    mergeFieldAliasMaps = Map.unionWith (<>)
+
+    spanRecordFieldAliasesForVars :: Set Name -> RealSrcSpan -> Map String (Set String)
+    spanRecordFieldAliasesForVars vars span' =
+        let varOccs = Set.fromList $ map (occNameString . nameOccName) $ Set.toList vars
+            (_, _, aliasesByField) =
+                foldl' (collectRecordFieldAliases varOccs) (False, Nothing, Map.empty) (srcLinesInSpan span')
+        in aliasesByField
+
+    collectRecordFieldAliases
+        :: Set String
+        -> (Bool, Maybe (Map String (Set String), Bool), Map String (Set String))
+        -> ByteString
+        -> (Bool, Maybe (Map String (Set String), Bool), Map String (Set String))
+    collectRecordFieldAliases varOccs (pendingTxOutIntro, activeCapture, aliasesByField) rawLine =
+        let line = lineCodePart rawLine
+            hasTxOutWord = containsWordBS "TxOut" line
+            hasOpenBrace = BS8.elem '{' line
+            lineAliases = parseRecordFieldAliasesFromLine line
+            commitAliases rhsOcc aliasesToCommit =
+                if Set.null varOccs || rhsOcc `Set.member` varOccs
+                    then mergeFieldAliasMaps aliasesByField aliasesToCommit
+                    else aliasesByField
+        in case activeCapture of
+            Nothing
+                | hasOpenBrace && (hasTxOutWord || pendingTxOutIntro) ->
+                    case parseRecordPatternBoundVar line of
+                        Just rhsOcc ->
+                            ( False
+                            , Nothing
+                            , commitAliases rhsOcc lineAliases
+                            )
+                        Nothing ->
+                            (False, Just (lineAliases, BS8.elem '}' line), aliasesByField)
+                | otherwise ->
+                    (hasTxOutWord && not hasOpenBrace, Nothing, aliasesByField)
+            Just (capturedAliases, waitingBoundVarAfterClose) ->
+                let capturedAliases' = mergeFieldAliasMaps capturedAliases lineAliases
+                    rhsOcc = if waitingBoundVarAfterClose
+                        then parseRecordPatternBoundVarOnly line
+                        else parseRecordPatternBoundVar line
+                in case rhsOcc of
+                    Just boundOcc ->
+                        ( False
+                        , Nothing
+                        , commitAliases boundOcc capturedAliases'
+                        )
+                    Nothing ->
+                        ( False
+                        , Just (capturedAliases', waitingBoundVarAfterClose || BS8.elem '}' line)
+                        , aliasesByField
+                        )
+
+    parseRecordFieldAliasesFromLine :: ByteString -> Map String (Set String)
+    parseRecordFieldAliasesFromLine line =
+        foldl'
+            (\acc segment -> case parseRecordFieldAliasSegment segment of
+                Nothing -> acc
+                Just (fieldKey, aliasOcc) ->
+                    Map.insertWith (<>) fieldKey (Set.singleton aliasOcc) acc
+            )
+            Map.empty
+            (BS8.split ',' line)
+
+    parseRecordFieldAliasSegment :: ByteString -> Maybe (String, String)
+    parseRecordFieldAliasSegment segment = case parseRecordFieldAliasAssignment segment of
+        Just parsedAlias -> Just parsedAlias
+        Nothing -> parseRecordFieldAliasPun segment
+
+    parseRecordFieldAliasAssignment :: ByteString -> Maybe (String, String)
+    parseRecordFieldAliasAssignment segment = do
+        let (lhsRaw, eqAndRhs) = BS8.break (== '=') segment
+        guard (not $ BS8.null eqAndRhs)
+        guard (not $ BS8.isPrefixOf "==" eqAndRhs)
+        fieldOcc <- lastWordOcc lhsRaw
+        fieldKey <- txOutFieldKeyFromOcc fieldOcc
+        aliasOcc <- firstWordOccLoose $ BS8.drop 1 eqAndRhs
+        pure (fieldKey, aliasOcc)
+
+    parseRecordFieldAliasPun :: ByteString -> Maybe (String, String)
+    parseRecordFieldAliasPun segment = do
+        let (_lhsRaw, eqAndRhs) = BS8.break (== '=') segment
+        guard (BS8.null eqAndRhs)
+        fieldOcc <- lastWordOcc segment
+        fieldKey <- txOutFieldKeyFromOcc fieldOcc
+        pure (fieldKey, fieldOcc)
+
+    txOutFieldKeyFromOcc :: String -> Maybe String
+    txOutFieldKeyFromOcc = \case
+        "txOutAddress" -> Just fieldKeyAddress
+        "txOutValue" -> Just fieldKeyValue
+        "txOutDatum" -> Just fieldKeyDatum
+        "txOutReferenceScript" -> Just fieldKeyReference
+        "referenceScript" -> Just fieldKeyReference
+        _ -> Nothing
+
+    parseRecordPatternBoundVar :: ByteString -> Maybe String
+    parseRecordPatternBoundVar line = do
+        let (_beforeClose, closeAndRest) = BS8.break (== '}') line
+        guard (not $ BS8.null closeAndRest)
+        parseRecordPatternBoundVarOnly $ BS8.drop 1 closeAndRest
+
+    parseRecordPatternBoundVarOnly :: ByteString -> Maybe String
+    parseRecordPatternBoundVarOnly line = do
+        let (_beforeEq, eqAndRhs) = BS8.break (== '=') line
+        guard (not $ BS8.null eqAndRhs)
+        guard (not $ BS8.isPrefixOf "==" eqAndRhs)
+        firstWordOccLoose $ BS8.drop 1 eqAndRhs
     connectedComponents :: Set Name -> [(Name, Name)] -> [Set Name]
     connectedComponents vars edges = go vars []
       where
@@ -3071,9 +3230,35 @@ analyseMissingTxOutFieldCheck missingField insId hie curNode =
 
         nodeLooksLikeAddressEquality :: HieAST TypeIndex -> Bool
         nodeLooksLikeAddressEquality n =
-            isOneLineSpan (nodeSpan n)
+            (isOneLineSpan (nodeSpan n)
                 && nodeHasAnyTxOutFieldToken ["txOutAddress"] n
                 && subtreeHasEqOperator n
+            )
+                || spanLooksLikeAddressEquality (nodeSpan n)
+
+        spanLooksLikeAddressEquality :: RealSrcSpan -> Bool
+        spanLooksLikeAddressEquality span' =
+            any lineHasAddressEqualityPattern (srcNumberedLinesInSpan span')
+
+        lineHasAddressEqualityPattern :: (Int, ByteString) -> Bool
+        lineHasAddressEqualityPattern (lineNumber, line) =
+            let prevLine = srcLineAt (lineNumber - 1)
+                nextLine = srcLineAt (lineNumber + 1)
+                lineIsAddressOperand = lineLooksLikeAddressOperandToken line
+                adjacentEq =
+                    maybe False lineHasEqOperator prevLine
+                        || lineHasEqOperator line
+                        || maybe False lineHasEqOperator nextLine
+                adjacentAddressOperand =
+                    maybe False lineLooksLikeAddressOperandToken prevLine
+                        || lineIsAddressOperand
+                        || maybe False lineLooksLikeAddressOperandToken nextLine
+            in adjacentEq && adjacentAddressOperand
+
+        lineLooksLikeAddressOperandToken :: ByteString -> Bool
+        lineLooksLikeAddressOperandToken line =
+            parseBindingLhs line == Nothing
+                && containsWordBS "txOutAddress" (lineCodePart line)
 
     subtreeHasEqName :: HieAST TypeIndex -> Bool
     subtreeHasEqName n@Node{nodeChildren = children} =
@@ -3089,9 +3274,12 @@ analyseMissingTxOutFieldCheck missingField insId hie curNode =
     spanMentionsEqOperator span' =
         any lineHasEqOperator (srcLinesInSpan span')
 
+    lineCodePart :: ByteString -> ByteString
+    lineCodePart = fst . BS8.breakSubstring "--"
+
     lineHasEqOperator :: ByteString -> Bool
     lineHasEqOperator line =
-        "==" `BS8.isInfixOf` line && not ("/=" `BS8.isInfixOf` line)
+        "==" `BS8.isInfixOf` lineCodePart line
 
     srcLinesInSpan :: RealSrcSpan -> [ByteString]
     srcLinesInSpan span' =
@@ -3105,6 +3293,11 @@ analyseMissingTxOutFieldCheck missingField insId hie curNode =
         in mapMaybe
             (\lineNumber -> (lineNumber,) <$> (allLines !!? (lineNumber - 1)))
             [start .. end]
+
+
+    srcLineAt :: Int -> Maybe ByteString
+    srcLineAt lineNumber =
+        (BS8.lines $ hie_hs_src hie) !!? (lineNumber - 1)
 
     subtreeHasAnyTxOutFieldToken :: [String] -> HieAST TypeIndex -> Bool
     subtreeHasAnyTxOutFieldToken targets = go
@@ -3126,37 +3319,234 @@ analyseMissingTxOutFieldCheck missingField insId hie curNode =
     spanMentionsAnyFieldTokenForVars tokens vars span' =
         let varOccs = map (occNameString . nameOccName) $ Set.toList vars
             numberedLines = srcNumberedLinesInSpan span'
+            lineByNumber = srcLineAt
         in any
             (\(lineNumber, line) ->
-                let mentionsField =
-                        any (\varOcc -> lineMentionsFieldTokenForVar tokens varOcc line) varOccs
+                let prevPrevLine = lineByNumber (lineNumber - 2)
+                    prevLine = lineByNumber (lineNumber - 1)
+                    nextLine = lineByNumber (lineNumber + 1)
+                    nextNextLine = lineByNumber (lineNumber + 2)
+                    mentionsField =
+                        any
+                            (\varOcc ->
+                                lineMentionsFieldTokenForVarAdjacent
+                                    tokens
+                                    varOcc
+                                    prevLine
+                                    line
+                                    nextLine
+                                    || (maybe False isSkippableCodeLine nextLine
+                                        && lineMentionsFieldTokenForVarAdjacent
+                                            tokens
+                                            varOcc
+                                            prevLine
+                                            line
+                                            nextNextLine
+                                       )
+                                    || (maybe False isSkippableCodeLine prevLine
+                                        && lineMentionsFieldTokenForVarAdjacent
+                                            tokens
+                                            varOcc
+                                            prevPrevLine
+                                            line
+                                            nextLine
+                                       )
+                            )
+                            varOccs
                 in mentionsField
                     && not (isUnusedBindingLine numberedLines lineNumber line)
             )
             numberedLines
-
     spanMentionsAddressEqForVars :: Set Name -> RealSrcSpan -> Bool
     spanMentionsAddressEqForVars vars span' =
         let varOccs = map (occNameString . nameOccName) $ Set.toList vars
             numberedLines = srcNumberedLinesInSpan span'
+            lineByNumber = srcLineAt
         in any
             (\(lineNumber, line) ->
-                let mentionsEq =
-                        any (\varOcc -> lineMentionsAddressEqForVar varOcc line) varOccs
+                let prevLine = lineByNumber (lineNumber - 1)
+                    nextLine = lineByNumber (lineNumber + 1)
+                    mentionsEq =
+                        any
+                            (\varOcc ->
+                                lineMentionsAddressEqForVarAdjacent
+                                    varOcc
+                                    prevLine
+                                    line
+                                    nextLine
+                            )
+                            varOccs
                 in mentionsEq
                     && not (isUnusedBindingLine numberedLines lineNumber line)
             )
             numberedLines
+
+    spanMentionsAnyFieldTokenForOccs :: [String] -> Set String -> RealSrcSpan -> Bool
+    spanMentionsAnyFieldTokenForOccs tokens occs span'
+        | Set.null occs = False
+        | otherwise =
+            let occNames = Set.toList occs
+                numberedLines = srcNumberedLinesInSpan span'
+                lineByNumber = srcLineAt
+            in any
+                (\(lineNumber, line) ->
+                    let prevPrevLine = lineByNumber (lineNumber - 2)
+                        prevLine = lineByNumber (lineNumber - 1)
+                        nextLine = lineByNumber (lineNumber + 1)
+                        nextNextLine = lineByNumber (lineNumber + 2)
+                        mentionsField =
+                            any
+                                (\occ ->
+                                    lineMentionsFieldTokenForVarAdjacent
+                                        tokens
+                                        occ
+                                        prevLine
+                                        line
+                                        nextLine
+                                        || (maybe False isSkippableCodeLine nextLine
+                                            && lineMentionsFieldTokenForVarAdjacent
+                                                tokens
+                                                occ
+                                                prevLine
+                                                line
+                                                nextNextLine
+                                           )
+                                        || (maybe False isSkippableCodeLine prevLine
+                                            && lineMentionsFieldTokenForVarAdjacent
+                                                tokens
+                                                occ
+                                                prevPrevLine
+                                                line
+                                                nextLine
+                                           )
+                                )
+                                occNames
+                    in mentionsField
+                        && not (isUnusedBindingLine numberedLines lineNumber line)
+                )
+                numberedLines
+
+    spanMentionsAddressEqForOccs :: Set String -> RealSrcSpan -> Bool
+    spanMentionsAddressEqForOccs occs span'
+        | Set.null occs = False
+        | otherwise =
+            let occNames = Set.toList occs
+                numberedLines = srcNumberedLinesInSpan span'
+                lineByNumber = srcLineAt
+            in any
+                (\(lineNumber, line) ->
+                    let prevLine = lineByNumber (lineNumber - 1)
+                        nextLine = lineByNumber (lineNumber + 1)
+                        mentionsEq =
+                            any
+                                (\occ ->
+                                    lineMentionsAddressEqForOccAdjacent
+                                        occ
+                                        prevLine
+                                        line
+                                        nextLine
+                                )
+                                occNames
+                    in mentionsEq
+                        && not (isUnusedBindingLine numberedLines lineNumber line)
+                )
+                numberedLines
+
+    lineMentionsAddressEqForVarAdjacent :: String -> Maybe ByteString -> ByteString -> Maybe ByteString -> Bool
+    lineMentionsAddressEqForVarAdjacent varOcc prevLine line nextLine =
+        lineMentionsAddressEqForVar varOcc line
+            || (lineHasEqOperator line
+                && maybe False (lineLooksLikeAddressOperand varOcc) prevLine
+               )
+            || (lineHasEqOperator line
+                && maybe False (lineLooksLikeAddressOperand varOcc) nextLine
+               )
+            || (lineLooksLikeAddressOperand varOcc line
+                && maybe False lineHasEqOperator prevLine
+               )
+            || (lineLooksLikeAddressOperand varOcc line
+                && maybe False lineHasEqOperator nextLine
+               )
 
     lineMentionsAddressEqForVar :: String -> ByteString -> Bool
     lineMentionsAddressEqForVar varOcc line =
         lineHasEqOperator line
             && lineMentionsFieldTokenForVar ["txOutAddress"] varOcc line
 
+    lineLooksLikeAddressOperand :: String -> ByteString -> Bool
+    lineLooksLikeAddressOperand varOcc line =
+        parseBindingLhs line == Nothing
+            && lineMentionsFieldTokenForVar ["txOutAddress"] varOcc line
+
+    lineMentionsAddressEqForOccAdjacent :: String -> Maybe ByteString -> ByteString -> Maybe ByteString -> Bool
+    lineMentionsAddressEqForOccAdjacent occ prevLine line nextLine =
+        lineMentionsAddressEqForOcc occ line
+            || maybe False (lineMentionsAddressEqForOcc occ) prevLine
+            || maybe False (lineMentionsAddressEqForOcc occ) nextLine
+            || (lineHasEqOperator line
+                && maybe False (lineLooksLikeAddressAliasOperand occ) prevLine
+               )
+            || (lineHasEqOperator line
+                && maybe False (lineLooksLikeAddressAliasOperand occ) nextLine
+               )
+            || (lineLooksLikeAddressAliasOperand occ line
+                && maybe False lineHasEqOperator prevLine
+               )
+            || (lineLooksLikeAddressAliasOperand occ line
+                && maybe False lineHasEqOperator nextLine
+               )
+    lineMentionsAddressEqForOcc :: String -> ByteString -> Bool
+    lineMentionsAddressEqForOcc occ line =
+        lineHasEqOperator line
+            && lineMentionsVarOcc occ line
+
+    lineLooksLikeAddressAliasOperand :: String -> ByteString -> Bool
+    lineLooksLikeAddressAliasOperand occ line =
+        parseBindingLhs line == Nothing
+            && lineMentionsVarOcc occ line
+
+    lineMentionsFieldTokenForVarAdjacent :: [String] -> String -> Maybe ByteString -> ByteString -> Maybe ByteString -> Bool
+    lineMentionsFieldTokenForVarAdjacent tokens varOcc prevLine line nextLine =
+        lineMentionsFieldTokenForVar tokens varOcc line
+            || (lineHasAnyFieldToken tokens line
+                && parseBindingLhs line == Nothing
+                && maybe False (lineMentionsVarOcc varOcc) nextLine
+               )
+            || (lineMentionsVarOcc varOcc line
+                && maybe False
+                    (\prev -> parseBindingLhs prev == Nothing && lineHasAnyFieldToken tokens prev)
+                    prevLine
+               )
+            || (lineLooksLikeCaseScrutinee varOcc line
+                && maybe False
+                    (\next -> parseBindingLhs next == Nothing && lineHasAnyFieldToken tokens next)
+                    nextLine
+               )
+
+    lineMentionsVarOcc :: String -> ByteString -> Bool
+    lineMentionsVarOcc varOcc line =
+        containsWordBS (BS8.pack varOcc) (lineCodePart line)
+
+    lineLooksLikeCaseScrutinee :: String -> ByteString -> Bool
+    lineLooksLikeCaseScrutinee varOcc line =
+        let code = lineCodePart line
+        in parseBindingLhs line == Nothing
+            && containsWordBS "case" code
+            && containsWordBS "of" code
+            && containsWordBS (BS8.pack varOcc) code
+    isSkippableCodeLine :: ByteString -> Bool
+    isSkippableCodeLine line =
+        BS8.null $ BS8.dropWhile isSpace $ lineCodePart line
+
     lineMentionsFieldTokenForVar :: [String] -> String -> ByteString -> Bool
     lineMentionsFieldTokenForVar tokens varOcc line =
-        containsWordBS (BS8.pack varOcc) line
-            && any (\tok -> containsWordBS (BS8.pack tok) line) tokens
+        lineMentionsVarOcc varOcc line
+            && lineHasAnyFieldToken tokens line
+
+    lineHasAnyFieldToken :: [String] -> ByteString -> Bool
+    lineHasAnyFieldToken tokens line =
+        let code = lineCodePart line
+        in any (\tok -> containsWordBS (BS8.pack tok) code) tokens
 
     isUnusedBindingLine :: [(Int, ByteString)] -> Int -> ByteString -> Bool
     isUnusedBindingLine numberedLines lineNumber line = case parseBindingLhs line of
@@ -3188,6 +3578,13 @@ analyseMissingTxOutFieldCheck missingField insId hie curNode =
         guard (not $ BS8.null word)
         pure (BS8.unpack word, BS8.dropWhile isSpace rest)
 
+
+    firstWordOccLoose :: ByteString -> Maybe String
+    firstWordOccLoose bs = do
+        let trimmed = BS8.dropWhile (\c -> isSpace c || c == '{' || c == '}') bs
+            word = BS8.takeWhile isIdentifierChar trimmed
+        guard (not $ BS8.null word)
+        pure (BS8.unpack word)
     lastWordOcc :: ByteString -> Maybe String
     lastWordOcc bs = do
         let trimmed = trimRight bs

--- a/src/Stan/Inspection.hs
+++ b/src/Stan/Inspection.hs
@@ -132,6 +132,14 @@ data InspectionAnalysis
     | RedeemerSuppliedIndicesUniqueness
     -- | `&&` used in on-chain code (prefer strict builtinAnd).
     | LazyAndInOnChainCode
+    -- | TxOut validation misses reference script checks.
+    | MissingTxOutReferenceScriptCheck
+    -- | TxOut validation misses staking credential checks.
+    | MissingTxOutStakingCredentialCheck
+    -- | TxOut validation misses value checks.
+    | MissingTxOutValueCheck
+    -- | TxOut validation misses datum checks.
+    | MissingTxOutDatumCheck
     deriving stock (Show, Eq)
 
 -- | Show 'Inspection' in a human-friendly format.

--- a/src/Stan/Inspection/AntiPattern.hs
+++ b/src/Stan/Inspection/AntiPattern.hs
@@ -60,9 +60,13 @@ module Stan.Inspection.AntiPattern
     , plustan10
     , plustan11
     , plustan12
+    , plustan13
+    , plustan14
+    , plustan15
     , plustan16
     , plustan17
     , plustan18
+    , plustan19
     -- * All inspections
     , antiPatternInspectionsMap
     ) where
@@ -122,9 +126,13 @@ antiPatternInspectionsMap = fromList $ fmapToFst inspectionId
     , plustan10
     , plustan11
     , plustan12
+    , plustan13
+    , plustan14
+    , plustan15
     , plustan16
     , plustan17
     , plustan18
+    , plustan19
     ]
 
 -- | Smart constructor to create anti-pattern 'Inspection'.
@@ -740,6 +748,39 @@ plustan12 = mkAntiPatternInspection (Id "PLU-STAN-12") "Validity interval / POSI
     & withPlutusCategory
     & severityL .~ Warning
 
+plustan13 :: Inspection
+plustan13 = mkAntiPatternInspection (Id "PLU-STAN-13") "TxOut validation misses reference script checks"
+    MissingTxOutReferenceScriptCheck
+    & descriptionL .~ "Validation logic over TxOut/TxOutAsData checks multiple output fields but does not enforce reference script constraints."
+    & solutionL .~
+        [ "If the output is security-critical, assert expected reference-script policy explicitly"
+        , "Document intentional omission and suppress with an inline ignore when reference script is irrelevant"
+        ]
+    & withPlutusCategory
+    & severityL .~ Warning
+
+plustan14 :: Inspection
+plustan14 = mkAntiPatternInspection (Id "PLU-STAN-14") "TxOut validation misses staking credential checks"
+    MissingTxOutStakingCredentialCheck
+    & descriptionL .~ "Validation logic over TxOut/TxOutAsData checks multiple output fields but does not enforce staking credential constraints."
+    & solutionL .~
+        [ "Validate staking credential policy for critical outputs (or enforce it indirectly via full address checks)"
+        , "If staking credential is intentionally irrelevant, document that decision and suppress the warning"
+        ]
+    & withPlutusCategory
+    & severityL .~ Warning
+
+plustan15 :: Inspection
+plustan15 = mkAntiPatternInspection (Id "PLU-STAN-15") "TxOut validation misses value checks"
+    MissingTxOutValueCheck
+    & descriptionL .~ "Validation logic over TxOut/TxOutAsData checks multiple output fields but does not constrain output value."
+    & solutionL .~
+        [ "Add explicit value/accounting constraints for the validated output"
+        , "At minimum, assert required assets/amounts and disallow unauthorized extras where relevant"
+        ]
+    & withPlutusCategory
+    & severityL .~ Warning
+
 plustan16 :: Inspection
 plustan16 = mkAntiPatternInspection (Id "PLU-STAN-16") "Precision loss: division before multiplication"
     PrecisionLossDivisionBeforeMultiply
@@ -771,6 +812,17 @@ plustan18 = mkAntiPatternInspection (Id "PLU-STAN-18") "Avoid lazy (&&) in on-ch
         [ "Use a strict combinator such as:"
         , "{-# INLINE builtinAnd #-}; builtinAnd :: Bool -> Bool -> Bool; builtinAnd b1 b2 = BI.ifThenElse b1 b2 False"
         , "If the RHS intentionally throws (e.g. error/traceError), keep (&&) to preserve behaviour."
+        ]
+    & withPlutusCategory
+    & severityL .~ Warning
+
+plustan19 :: Inspection
+plustan19 = mkAntiPatternInspection (Id "PLU-STAN-19") "TxOut validation misses datum checks"
+    MissingTxOutDatumCheck
+    & descriptionL .~ "Validation logic over TxOut/TxOutAsData checks multiple output fields but does not validate datum/output-datum constraints."
+    & solutionL .~
+        [ "Validate datum shape and critical datum fields for security-sensitive outputs"
+        , "If datum is intentionally unconstrained, document this and suppress the warning"
         ]
     & withPlutusCategory
     & severityL .~ Warning

--- a/stan.cabal
+++ b/stan.cabal
@@ -199,6 +199,7 @@ executable plustan
                      , ghc >= 8.8 && < 9.13
                      , ghc-boot >= 8.8 && < 9.13
                      , ghc-paths
+                     , microaeson ^>= 0.1.0.0
                      , process
                      , slist >= 0.1 && < 0.3
                      , text

--- a/target/Target/PlutusTx.hs
+++ b/target/Target/PlutusTx.hs
@@ -1283,3 +1283,125 @@ plutStan13EdgeUnusedReferenceBinding out =
       && hasStakingCredential out
       && hasOutputValue out
       && hasOutputDatum out
+
+plutStan14EqNeqSameLineShouldPass :: TxOut -> Address -> Integer -> Bool
+-- PLU-STAN-14 (should NOT trigger): address equality remains valid even with (/=) on same line.
+plutStan14EqNeqSameLineShouldPass out expected n =
+  txOutAddress out == expected && n /= 0
+    && hasOutputValue out
+    && hasOutputDatum out
+    && hasReferenceScript out
+
+plutStan13MultilineReferenceShouldPass :: TxOut -> Bool
+-- PLU-STAN-13 (should NOT trigger): reference check function/value split across lines still counts.
+plutStan13MultilineReferenceShouldPass out =
+  hasOutputAddress out
+    && hasStakingCredential out
+    && hasOutputValue out
+    && hasOutputDatum out
+    && hasReferenceScript
+         out
+
+plutStan14MultilineAddressEqShouldPass :: TxOut -> Address -> Bool
+-- PLU-STAN-14 (should NOT trigger): address equality split across lines still implies staking checks.
+plutStan14MultilineAddressEqShouldPass out expected =
+  txOutAddress out
+    == expected
+    && hasOutputValue out
+    && hasOutputDatum out
+    && hasReferenceScript out
+
+plutStan13CommentedReferenceShouldTrigger :: TxOut -> Bool
+-- PLU-STAN-13 (should trigger): comment-only reference token must not count as a check.
+plutStan13CommentedReferenceShouldTrigger out =
+  hasOutputAddress out
+    && hasStakingCredential out
+    && hasOutputValue out
+    && hasOutputDatum out
+    -- hasReferenceScript out
+
+plutStan14CommentedAddressEqShouldTrigger :: TxOut -> Integer -> Bool
+-- PLU-STAN-14 (should trigger): comment-only address equality token must not imply staking checks.
+plutStan14CommentedAddressEqShouldTrigger out n =
+  hasOutputAddress out
+    && hasOutputValue out
+    && hasOutputDatum out
+    && hasReferenceScript out
+    && n == 0
+    -- txOutAddress out == expected
+
+plutStan13MultilineReferenceWithCommentShouldPass :: TxOut -> Bool
+-- PLU-STAN-13 (should NOT trigger): comment line between function and argument still counts the check.
+plutStan13MultilineReferenceWithCommentShouldPass out =
+  hasOutputAddress out
+    && hasStakingCredential out
+    && hasOutputValue out
+    && hasOutputDatum out
+    && hasReferenceScript
+    -- intentionally split for formatter behavior
+    out
+
+plutStan13RecordDestructureMissingReferenceShouldTrigger :: TxOut -> Address -> Bool
+-- PLU-STAN-13 (should trigger): record-destructured TxOut checks omit reference script validation.
+plutStan13RecordDestructureMissingReferenceShouldTrigger out ownAddress =
+  let TxOut
+        { txOutAddress = address
+        , txOutValue = value
+        , txOutDatum = datum
+        , txOutReferenceScript = _referenceScript
+        } = out
+  in address == ownAddress
+      && Value.valueOf value Value.adaSymbol Value.adaToken >= 0
+      && case datum of
+           OutputDatum _ -> True
+           _ -> False
+
+plutStan13RecordDestructureAllCheckedShouldPass :: TxOut -> Address -> Bool
+-- PLU-STAN-13 (should NOT trigger): record-destructured TxOut validates all fields.
+plutStan13RecordDestructureAllCheckedShouldPass out ownAddress =
+  let TxOut
+        { txOutAddress = address
+        , txOutValue = value
+        , txOutDatum = datum
+        , txOutReferenceScript = referenceScript
+        } = out
+  in address == ownAddress
+      && Value.valueOf value Value.adaSymbol Value.adaToken >= 0
+      && case datum of
+           OutputDatum _ -> True
+           _ -> False
+      && referenceScript == Nothing
+
+plutStan14RecordDestructureMissingStakingShouldTrigger :: TxOut -> Bool
+-- PLU-STAN-14 (should trigger): record-destructured checks omit staking validation.
+plutStan14RecordDestructureMissingStakingShouldTrigger out =
+  let TxOut
+        { txOutAddress = address
+        , txOutValue = value
+        , txOutDatum = datum
+        , txOutReferenceScript = referenceScript
+        } = out
+  in (case address of
+        Address _ _ -> True
+        _ -> False)
+      && Value.valueOf value Value.adaSymbol Value.adaToken >= 0
+      && case datum of
+           OutputDatum _ -> True
+           _ -> False
+      && referenceScript == Nothing
+
+plutStan14RecordDestructureAddressEqShouldPass :: TxOut -> Address -> Bool
+-- PLU-STAN-14 (should NOT trigger): address equality on destructured address implies staking checks.
+plutStan14RecordDestructureAddressEqShouldPass out ownAddress =
+  let TxOut
+        { txOutAddress = address
+        , txOutValue = value
+        , txOutDatum = datum
+        , txOutReferenceScript = referenceScript
+        } = out
+  in address == ownAddress
+      && Value.valueOf value Value.adaSymbol Value.adaToken >= 0
+      && case datum of
+           OutputDatum _ -> True
+           _ -> False
+      && referenceScript == Nothing

--- a/test/Test/Stan/Analysis/PlutusTx.hs
+++ b/test/Test/Stan/Analysis/PlutusTx.hs
@@ -12,9 +12,13 @@ module Test.Stan.Analysis.PlutusTx (
   plustan10Spec,
   plustan11Spec,
   plustan12Spec,
+  plustan13Spec,
+  plustan14Spec,
+  plustan15Spec,
   plustan16Spec,
   plustan17Spec,
   plustan18Spec,
+  plustan19Spec,
 ) where
 
 import Test.Hspec (Spec, describe, it)
@@ -38,9 +42,13 @@ analysisPlutusTxSpec analysis = describe "Plutus-Tx" $ do
   plustan10Spec analysis
   plustan11Spec analysis
   plustan12Spec analysis
+  plustan13Spec analysis
+  plustan14Spec analysis
+  plustan15Spec analysis
   plustan16Spec analysis
   plustan17Spec analysis
   plustan18Spec analysis
+  plustan19Spec analysis
 
 plustan01Spec :: Analysis -> Spec
 plustan01Spec analysis = describe "PLU-STAN-01" $ do
@@ -264,6 +272,138 @@ plustan12Spec analysis = describe "PLU-STAN-12" $ do
   it "custom full validation (both bounds) should not trigger" $
     noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan12 932
 
+plustan13Spec :: Analysis -> Spec
+plustan13Spec analysis = describe "PLU-STAN-13" $ do
+  let checkObservation = observationAssert ["PlutusTx"] analysis
+
+  it "flags output validation that omits reference script checks" $
+    checkObservation AntiPattern.plustan13 975 3 19
+
+  it "flags exact-3-field coverage that omits reference script" $
+    checkObservation AntiPattern.plustan13 1025 3 19
+
+  it "does not flag non-TxOut code with token-like local names" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan13 1116
+
+  it "does not flag when only two output fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan13 1058
+
+  it "flags if/then/else validation that omits reference script checks" $
+    checkObservation AntiPattern.plustan13 1064 6 22
+
+  it "flags strict combinator validation that omits reference script checks" $
+    checkObservation AntiPattern.plustan13 1072 24 40
+
+  it "flags long-spanning validation bindings that omit reference script checks" $
+    checkObservation AntiPattern.plustan13 1078 12 28
+
+  it "flags custom conjunction operators that omit reference script checks" $
+    checkObservation AntiPattern.plustan13 1108 3 19
+
+  it "flags TxOutAsData coverage that omits reference script checks" $
+    checkObservation AntiPattern.plustan13 1141 6 22
+
+  it "does not flag TxOutAsData when all fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan13 1178
+
+  it "flags recursive if-based validation that omits reference script checks" $
+    checkObservation AntiPattern.plustan13 1186 6 22
+
+  it "flags cross-output reference checks as missing on the validated output" $
+    checkObservation AntiPattern.plustan13 1241 3 19
+
+  it "flags alias-split checks as one output missing reference checks" $
+    checkObservation AntiPattern.plustan13 1260 6 22
+
+  it "flags pattern-destructured checks that omit reference script checks" $
+    checkObservation AntiPattern.plustan13 1271 11 18
+
+  it "flags unused reference-binding checks as still missing reference checks" $
+    checkObservation AntiPattern.plustan13 1281 20 38
+
+  it "does not flag when all TxOut fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan13 1010
+
+plustan14Spec :: Analysis -> Spec
+plustan14Spec analysis = describe "PLU-STAN-14" $ do
+  let checkObservation = observationAssert ["PlutusTx"] analysis
+
+  it "flags output validation that omits staking credential checks" $
+    checkObservation AntiPattern.plustan14 984 3 19
+
+  it "flags exact-3-field coverage that omits staking checks" $
+    checkObservation AntiPattern.plustan14 1032 3 19
+
+  it "does not flag full-address equality as missing staking checks" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1125
+
+  it "does not flag when only two output fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1058
+
+  it "does not flag when validation has no (&&) (if/then/else form)" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1064
+
+  it "does not flag when conjunction is encoded without (&&)" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1071
+
+  it "does not flag long-spanning validation bindings" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1078
+
+  it "does not flag custom conjunction operators that avoid (&&) token" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1108
+
+  it "flags TxOutAsData coverage that omits staking checks" $
+    checkObservation AntiPattern.plustan14 1150 6 22
+
+  it "does not flag TxOutAsData when all fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1178
+
+  it "flags recursive if-based validation that omits staking checks" $
+    checkObservation AntiPattern.plustan14 1197 6 22
+
+  it "flags unrelated (==) + address-token usage as missing staking checks" $
+    checkObservation AntiPattern.plustan14 1230 15 27
+
+  it "does not flag when all TxOut fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1010
+
+plustan15Spec :: Analysis -> Spec
+plustan15Spec analysis = describe "PLU-STAN-15" $ do
+  let checkObservation = observationAssert ["PlutusTx"] analysis
+
+  it "flags output validation that omits value checks" $
+    checkObservation AntiPattern.plustan15 993 3 19
+
+  it "flags helper-indirected checks that omit value constraints" $
+    checkObservation AntiPattern.plustan15 1039 16 32
+
+  it "does not flag when only two output fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan15 1058
+
+  it "does not flag when validation has no (&&) (if/then/else form)" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan15 1064
+
+  it "does not flag when conjunction is encoded without (&&)" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan15 1071
+
+  it "does not flag long-spanning validation bindings" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan15 1078
+
+  it "does not flag custom conjunction operators that avoid (&&) token" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan15 1108
+
+  it "flags TxOutAsData coverage that omits value checks" $
+    checkObservation AntiPattern.plustan15 1159 6 22
+
+  it "does not flag TxOutAsData when all fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan15 1178
+
+  it "flags recursive if-based validation that omits value checks" $
+    checkObservation AntiPattern.plustan15 1208 6 22
+
+  it "does not flag when all TxOut fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan15 1010
+
 plustan16Spec :: Analysis -> Spec
 plustan16Spec analysis = describe "PLU-STAN-16" $ do
   let checkObservation = observationAssert ["PlutusTx"] analysis
@@ -354,3 +494,43 @@ plustan18Spec analysis = describe "PLU-STAN-18" $ do
 
   it "flags (&&) inside predicate helper with failing branch" $
     checkObservation AntiPattern.plustan18 843 4 6
+
+plustan19Spec :: Analysis -> Spec
+plustan19Spec analysis = describe "PLU-STAN-19" $ do
+  let checkObservation = observationAssert ["PlutusTx"] analysis
+
+  it "flags output validation that omits datum checks" $
+    checkObservation AntiPattern.plustan19 1002 3 19
+
+  it "flags mixed pattern/helper validation that omits datum checks" $
+    checkObservation AntiPattern.plustan19 1048 9 21
+
+  it "does not flag when only two output fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan19 1058
+
+  it "flags if/then/else validation that omits datum checks" $
+    checkObservation AntiPattern.plustan19 1064 6 22
+
+  it "flags strict combinator validation that omits datum checks" $
+    checkObservation AntiPattern.plustan19 1072 24 40
+
+  it "flags long-spanning validation bindings that omit datum checks" $
+    checkObservation AntiPattern.plustan19 1078 12 28
+
+  it "does not flag custom conjunction operators that avoid (&&) token" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan19 1108
+
+  it "flags TxOutAsData coverage that omits datum checks" $
+    checkObservation AntiPattern.plustan19 1168 6 22
+
+  it "does not flag TxOutAsData when all fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan19 1178
+
+  it "flags recursive if-based validation that omits datum checks" $
+    checkObservation AntiPattern.plustan19 1219 6 22
+
+  it "flags cross-output datum checks as missing on the validated output" $
+    checkObservation AntiPattern.plustan19 1250 3 19
+
+  it "does not flag when all TxOut fields are checked" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan19 1010

--- a/test/Test/Stan/Analysis/PlutusTx.hs
+++ b/test/Test/Stan/Analysis/PlutusTx.hs
@@ -321,6 +321,21 @@ plustan13Spec analysis = describe "PLU-STAN-13" $ do
   it "flags unused reference-binding checks as still missing reference checks" $
     checkObservation AntiPattern.plustan13 1281 20 38
 
+  it "does not flag multiline reference checks split across lines" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan13 1298
+
+  it "flags when reference appears only in a comment" $
+    checkObservation AntiPattern.plustan13 1317 3 19
+
+  it "does not flag multiline reference checks with an intervening comment line" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan13 1336
+
+  it "flags record-destructured TxOut checks that omit reference script validation" $
+    checkObservation AntiPattern.plustan13 1354 10 23
+
+  it "does not flag record-destructured TxOut checks when all fields are validated" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan13 1368
+
   it "does not flag when all TxOut fields are checked" $
     noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan13 1010
 
@@ -363,6 +378,21 @@ plustan14Spec analysis = describe "PLU-STAN-14" $ do
 
   it "flags unrelated (==) + address-token usage as missing staking checks" $
     checkObservation AntiPattern.plustan14 1230 15 27
+
+  it "does not flag address equality when (==) and (/=) share a line" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1290
+
+  it "does not flag address equality when (==) is split across lines" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1308
+
+  it "flags when address equality appears only in a comment" $
+    checkObservation AntiPattern.plustan14 1326 3 19
+
+  it "flags record-destructured TxOut checks that omit staking validation" $
+    checkObservation AntiPattern.plustan14 1385 9 16
+
+  it "does not flag record-destructured address equality with full field checks" $
+    noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1402
 
   it "does not flag when all TxOut fields are checked" $
     noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan14 1010

--- a/vscode-plustan/.vscodeignore
+++ b/vscode-plustan/.vscodeignore
@@ -1,0 +1,6 @@
+.vscode/**
+src/**
+tsconfig.json
+**/*.map
+**/*.ts
+node_modules/**

--- a/vscode-plustan/README.md
+++ b/vscode-plustan/README.md
@@ -1,0 +1,52 @@
+# Plu-Stan VS Code/Cursor Extension (MVP)
+
+This extension integrates the local `plustan` CLI.
+
+It is implemented as a standard VS Code extension, so it can be used in both VS Code and Cursor.
+
+## Features
+
+- Explorer Tree View for modules annotated with `onchain-contract`.
+- Large action rows at the top of the tree for refresh/run/clear/output actions.
+- Run `plustan` for a selected onchain module.
+- Run `plustan` for the full workspace.
+- Publish findings to VS Code Diagnostics / Problems.
+
+## Requirements
+
+- `plustan.binaryPath` must be set to an absolute `plustan` executable path.
+- A buildable Haskell workspace with `.hie`/`.hi` artifacts (the CLI will auto-build when needed).
+
+## Install In Cursor
+
+1. Build extension assets:
+```bash
+npm install
+npm run compile
+```
+2. Package as VSIX:
+```bash
+npm run package:vsix
+```
+3. In Cursor, run `Extensions: Install from VSIX...` and select the generated `.vsix`.
+
+For development host mode (if your `cursor` CLI is installed), you can launch:
+```bash
+cursor --extensionDevelopmentPath=/path/to/plu-stan/vscode-plustan --disable-extensions /path/to/workspace
+```
+
+## Commands
+
+- `Plu-Stan: Refresh Onchain Modules`
+- `Plu-Stan: Run Workspace`
+- `Plu-Stan: Run Module`
+- `Plu-Stan: Clear Diagnostics`
+- `Plu-Stan: Show Output`
+
+## Settings
+
+- `plustan.binaryPath`
+- `plustan.projectDir`
+- `plustan.hieDir`
+- `plustan.extraArgs`
+- `plustan.showOutputChannel`

--- a/vscode-plustan/media/plustan.svg
+++ b/vscode-plustan/media/plustan.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M4 6h16v4H4z" fill="#3EA6FF"/>
+  <path d="M4 11h16v7H4z" fill="#5FD18B"/>
+  <path d="M7 13h10v2H7z" fill="#0F172A"/>
+  <path d="M7 16h6v1.5H7z" fill="#0F172A"/>
+</svg>

--- a/vscode-plustan/package-lock.json
+++ b/vscode-plustan/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "vscode-plustan",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-plustan",
+      "version": "0.0.1",
+      "license": "MPL-2.0",
+      "devDependencies": {
+        "@types/node": "^20.14.10",
+        "@types/vscode": "^1.90.0",
+        "typescript": "^5.5.4"
+      },
+      "engines": {
+        "vscode": "^1.90.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.109.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.109.0.tgz",
+      "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode-plustan/package.json
+++ b/vscode-plustan/package.json
@@ -1,0 +1,129 @@
+{
+  "name": "vscode-plustan",
+  "displayName": "Plu-Stan (VS Code/Cursor)",
+  "description": "Standalone VS Code/Cursor extension for onchain module discovery and Plu-Stan analysis.",
+  "version": "0.0.8",
+  "publisher": "local",
+  "license": "MPL-2.0",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "keywords": [
+    "plu-stan",
+    "plutus",
+    "cardano",
+    "cursor",
+    "vscode"
+  ],
+  "categories": [
+    "Linters",
+    "Programming Languages"
+  ],
+  "activationEvents": [
+    "onView:plustanOnchainModules",
+    "onCommand:plustan.refreshOnchainModules",
+    "onCommand:plustan.runWorkspace",
+    "onCommand:plustan.runModule",
+    "onCommand:plustan.clearDiagnostics",
+    "onCommand:plustan.openOutput",
+    "onCommand:plustan.openSettings"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "plustan.refreshOnchainModules",
+        "title": "Plu-Stan: Refresh Onchain Modules"
+      },
+      {
+        "command": "plustan.runWorkspace",
+        "title": "Plu-Stan: Run Workspace"
+      },
+      {
+        "command": "plustan.runModule",
+        "title": "Plu-Stan: Run Module"
+      },
+      {
+        "command": "plustan.clearDiagnostics",
+        "title": "Plu-Stan: Clear Diagnostics"
+      },
+      {
+        "command": "plustan.openOutput",
+        "title": "Plu-Stan: Show Output"
+      },
+      {
+        "command": "plustan.openSettings",
+        "title": "Plu-Stan: Open Settings"
+      }
+    ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "plustan",
+          "title": "Plu-Stan",
+          "icon": "media/plustan.svg"
+        }
+      ]
+    },
+    "views": {
+      "plustan": [
+        {
+          "id": "plustanOnchainModules",
+          "name": "Plu-Stan Onchain Modules"
+        }
+      ]
+    },
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "plustan.runModule",
+          "when": "view == plustanOnchainModules && viewItem == plustanModule",
+          "group": "inline@1"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "Plu-Stan",
+      "properties": {
+        "plustan.binaryPath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to the plustan executable (required)."
+        },
+        "plustan.projectDir": {
+          "type": "string",
+          "default": "",
+          "description": "Optional project directory. If empty, uses the active workspace folder."
+        },
+        "plustan.hieDir": {
+          "type": "string",
+          "default": ".hie",
+          "description": "Directory containing .hie/.hi files, relative to projectDir unless absolute."
+        },
+        "plustan.extraArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Additional CLI arguments appended to `plustan analyze` runs."
+        },
+        "plustan.showOutputChannel": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show Plu-Stan output channel automatically when running commands."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "package:vsix": "npx @vscode/vsce package"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/vscode": "^1.90.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/vscode-plustan/src/extension.ts
+++ b/vscode-plustan/src/extension.ts
@@ -1,0 +1,733 @@
+import * as path from "node:path";
+import { spawn } from "node:child_process";
+import * as vscode from "vscode";
+
+type AnnotationSource = "hi" | "source" | "both";
+type RunScope = "all" | "module";
+
+interface OnchainModule {
+  moduleName: string;
+  file: string;
+  annotationSource: AnnotationSource;
+}
+
+interface ListOnchainPayload {
+  version: number;
+  workspaceRoot: string;
+  hieDir: string;
+  modules: OnchainModule[];
+}
+
+interface Inspection {
+  id: string;
+  name: string;
+  severity: string;
+  description: string;
+}
+
+interface Observation {
+  id: string;
+  inspectionId: string;
+  file: string;
+  moduleName: string;
+  startLine: number;
+  startCol: number;
+  endLine: number;
+  endCol: number;
+}
+
+interface AnalysisSection {
+  observations: Observation[];
+}
+
+interface AnalyzePayload {
+  version: number;
+  runScope: RunScope;
+  targetModule: string | null;
+  inspections: Inspection[];
+  analysis: AnalysisSection;
+}
+
+interface PluStanSettings {
+  binaryPath: string;
+  projectDir: string;
+  hieDir: string;
+  extraArgs: string[];
+  showOutputChannel: boolean;
+}
+
+class OnchainModuleItem extends vscode.TreeItem {
+  constructor(
+    readonly moduleInfo: OnchainModule,
+    workspaceRoot: string
+  ) {
+    super(moduleInfo.moduleName, vscode.TreeItemCollapsibleState.None);
+    this.description = toRelativePath(workspaceRoot, moduleInfo.file);
+    this.tooltip = `${moduleInfo.moduleName} (${moduleInfo.annotationSource})\n${moduleInfo.file}`;
+    this.contextValue = "plustanModule";
+    this.iconPath = new vscode.ThemeIcon("symbol-module");
+    this.command = {
+      command: "plustan.runModule",
+      title: "Run Module",
+      arguments: [this]
+    };
+  }
+}
+
+class ActionItem extends vscode.TreeItem {
+  constructor(
+    label: string,
+    description: string,
+    commandId: string,
+    title: string,
+    iconId: string
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.description = description;
+    this.contextValue = "plustanAction";
+    this.iconPath = new vscode.ThemeIcon(iconId);
+    this.command = {
+      command: commandId,
+      title
+    };
+  }
+}
+
+class MessageItem extends vscode.TreeItem {
+  constructor(
+    label: string,
+    description: string,
+    commandId: string
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.description = description;
+    this.contextValue = "plustanMessage";
+    this.iconPath = new vscode.ThemeIcon("warning");
+    this.command = {
+      command: commandId,
+      title: "Open Plu-Stan Settings"
+    };
+  }
+}
+
+type PluStanTreeItem = ActionItem | OnchainModuleItem | MessageItem;
+
+class OnchainModulesProvider implements vscode.TreeDataProvider<PluStanTreeItem> {
+  private modules: OnchainModule[] = [];
+  private workspaceRoot = "";
+  private binaryConfigured = false;
+  private readonly emitter = new vscode.EventEmitter<PluStanTreeItem | undefined>();
+
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  setData(modules: OnchainModule[], workspaceRoot: string): void {
+    this.modules = [...modules].sort((a, b) => a.moduleName.localeCompare(b.moduleName));
+    this.workspaceRoot = workspaceRoot;
+    this.emitter.fire(undefined);
+  }
+
+  setBinaryConfigured(configured: boolean): void {
+    this.binaryConfigured = configured;
+    if (!configured) {
+      this.modules = [];
+    }
+    this.emitter.fire(undefined);
+  }
+
+  getData(): OnchainModule[] {
+    return this.modules;
+  }
+
+  getTreeItem(element: PluStanTreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): Thenable<PluStanTreeItem[]> {
+    if (!this.binaryConfigured) {
+      return Promise.resolve([
+        new MessageItem(
+          "Set plustan.binaryPath to enable Plu-Stan",
+          "Open settings and configure the absolute executable path",
+          "plustan.openSettings"
+        )
+      ]);
+    }
+
+    const actionItems: ActionItem[] = [
+      new ActionItem("Run Workspace Analysis", "Run all onchain checks", "plustan.runWorkspace", "Run Workspace", "play-circle"),
+      new ActionItem("Refresh Onchain Modules", "Rescan module annotations", "plustan.refreshOnchainModules", "Refresh Onchain Modules", "refresh"),
+      new ActionItem("Clear Diagnostics", "Clear Problems panel entries", "plustan.clearDiagnostics", "Clear Diagnostics", "clear-all"),
+      new ActionItem("Show Plu-Stan Output", "Open extension output logs", "plustan.openOutput", "Show Output", "output")
+    ];
+
+    const moduleItems = this.modules.map((moduleInfo) => new OnchainModuleItem(moduleInfo, this.workspaceRoot));
+    return Promise.resolve([...actionItems, ...moduleItems]);
+  }
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  const output = vscode.window.createOutputChannel("Plu-Stan");
+  const diagnostics = vscode.languages.createDiagnosticCollection("plu-stan");
+  const provider = new OnchainModulesProvider();
+
+  context.subscriptions.push(output, diagnostics);
+  context.subscriptions.push(
+    vscode.window.registerTreeDataProvider("plustanOnchainModules", provider)
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("plustan.openSettings", async () => {
+      await vscode.commands.executeCommand("workbench.action.openSettings", "plustan.binaryPath");
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("plustan.refreshOnchainModules", async () => {
+      if (!await saveWorkspaceBeforeRun()) {
+        return;
+      }
+      const folder = getWorkspaceFolderOrNotify();
+      if (!folder) {
+        return;
+      }
+      const settings = await ensureBinaryConfigured(folder, provider);
+      if (!settings) {
+        return;
+      }
+      await withUserProgress("Refreshing onchain modules", async (token) => {
+        const payload = await runListOnchain(folder, output, token);
+        appendOnchainModulesSummary(payload, folder, output);
+        provider.setData(payload.modules, payload.workspaceRoot);
+        vscode.window.setStatusBarMessage(
+          `Plu-Stan: loaded ${payload.modules.length} onchain module(s)`,
+          3000
+        );
+      });
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("plustan.runWorkspace", async () => {
+      if (!await saveWorkspaceBeforeRun()) {
+        return;
+      }
+      const folder = getWorkspaceFolderOrNotify();
+      if (!folder) {
+        return;
+      }
+      const settings = await ensureBinaryConfigured(folder, provider);
+      if (!settings) {
+        return;
+      }
+      await withUserProgress("Running Plu-Stan on workspace", async (token) => {
+        const payload = await runAnalyze(folder, output, token);
+        appendAnalyzeSummary(payload, folder, output);
+        publishDiagnostics(payload, folder, diagnostics);
+        vscode.window.setStatusBarMessage(
+          `Plu-Stan: ${payload.analysis.observations.length} observation(s)`,
+          3000
+        );
+      });
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("plustan.runModule", async (item?: OnchainModuleItem) => {
+      if (!await saveWorkspaceBeforeRun()) {
+        return;
+      }
+      const folder = getWorkspaceFolderOrNotify();
+      if (!folder) {
+        return;
+      }
+      const settings = await ensureBinaryConfigured(folder, provider);
+      if (!settings) {
+        return;
+      }
+      await withUserProgress("Running Plu-Stan on module", async (token) => {
+        const moduleName = item?.moduleInfo.moduleName ?? (await pickModuleName(provider, folder, output, token));
+        if (!moduleName) {
+          return;
+        }
+        const payload = await runAnalyze(folder, output, token, moduleName);
+        appendAnalyzeSummary(payload, folder, output);
+        publishDiagnostics(payload, folder, diagnostics);
+        vscode.window.setStatusBarMessage(
+          `Plu-Stan: ${moduleName} -> ${payload.analysis.observations.length} observation(s)`,
+          3000
+        );
+      });
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("plustan.clearDiagnostics", () => {
+      diagnostics.clear();
+      vscode.window.setStatusBarMessage("Plu-Stan diagnostics cleared", 2000);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("plustan.openOutput", () => {
+      output.show(true);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(async (event) => {
+      if (!event.affectsConfiguration("plustan.binaryPath")) {
+        return;
+      }
+      try {
+        const folder = getWorkspaceFolder();
+        const settings = readSettings(folder);
+        provider.setBinaryConfigured(hasConfiguredBinaryPath(settings));
+      } catch {
+        provider.setBinaryConfigured(false);
+      }
+    })
+  );
+
+  try {
+    const folder = getWorkspaceFolder();
+    const settings = readSettings(folder);
+    provider.setBinaryConfigured(hasConfiguredBinaryPath(settings));
+  } catch {
+    provider.setBinaryConfigured(false);
+  }
+}
+
+export function deactivate(): void {
+  // no-op
+}
+
+async function pickModuleName(
+  provider: OnchainModulesProvider,
+  folder: vscode.WorkspaceFolder,
+  output: vscode.OutputChannel,
+  token: vscode.CancellationToken
+): Promise<string | undefined> {
+  let modules = provider.getData();
+  if (modules.length === 0) {
+    const payload = await runListOnchain(folder, output, token);
+    provider.setData(payload.modules, payload.workspaceRoot);
+    modules = payload.modules;
+  }
+
+  if (modules.length === 0) {
+    vscode.window.showInformationMessage("Plu-Stan: no onchain modules found.");
+    return undefined;
+  }
+
+  const pick = await vscode.window.showQuickPick(
+    modules.map((moduleInfo) => ({
+      label: moduleInfo.moduleName,
+      description: toRelativePath(folder.uri.fsPath, moduleInfo.file),
+      detail: moduleInfo.annotationSource
+    })),
+    {
+      placeHolder: "Select onchain module"
+    }
+  );
+
+  return pick?.label;
+}
+
+async function runListOnchain(
+  folder: vscode.WorkspaceFolder,
+  output: vscode.OutputChannel,
+  token: vscode.CancellationToken
+): Promise<ListOnchainPayload> {
+  const settings = readSettings(folder);
+  const payload = await runPluStanJson<ListOnchainPayload>(
+    ["list-onchain", "--json", "--hiedir", settings.hieDir],
+    settings,
+    output,
+    token
+  );
+
+  if (!Array.isArray(payload.modules)) {
+    throw new Error("Invalid list-onchain payload: missing modules array");
+  }
+
+  return payload;
+}
+
+async function runAnalyze(
+  folder: vscode.WorkspaceFolder,
+  output: vscode.OutputChannel,
+  token: vscode.CancellationToken,
+  moduleName?: string
+): Promise<AnalyzePayload> {
+  const settings = readSettings(folder);
+  const args = ["analyze", "--json", "--hiedir", settings.hieDir, ...settings.extraArgs];
+  if (moduleName) {
+    args.push("--module", moduleName);
+  }
+
+  const payload = await runPluStanJson<AnalyzePayload>(args, settings, output, token);
+  if (!payload.analysis || !Array.isArray(payload.analysis.observations)) {
+    throw new Error("Invalid analyze payload: missing analysis observations");
+  }
+
+  return payload;
+}
+
+function publishDiagnostics(
+  payload: AnalyzePayload,
+  folder: vscode.WorkspaceFolder,
+  diagnostics: vscode.DiagnosticCollection
+): void {
+  diagnostics.clear();
+
+  const inspections = new Map(payload.inspections.map((inspection) => [inspection.id, inspection]));
+  const diagnosticsByFile = new Map<string, vscode.Diagnostic[]>();
+
+  for (const observation of payload.analysis.observations) {
+    const inspection = inspections.get(observation.inspectionId);
+    const filePath = path.isAbsolute(observation.file)
+      ? observation.file
+      : path.join(folder.uri.fsPath, observation.file);
+
+    const message = inspection
+      ? `[${observation.inspectionId}] ${inspection.name}`
+      : `[${observation.inspectionId}]`;
+
+    const diagnostic = new vscode.Diagnostic(
+      toRange(observation),
+      message,
+      mapSeverity(inspection?.severity)
+    );
+    diagnostic.source = "plu-stan";
+    diagnostic.code = observation.inspectionId;
+
+    const fileDiagnostics = diagnosticsByFile.get(filePath) ?? [];
+    fileDiagnostics.push(diagnostic);
+    diagnosticsByFile.set(filePath, fileDiagnostics);
+  }
+
+  diagnostics.set(
+    [...diagnosticsByFile.entries()].map(([filePath, fileDiagnostics]) => [
+      vscode.Uri.file(filePath),
+      fileDiagnostics
+    ])
+  );
+}
+
+function toRange(observation: Observation): vscode.Range {
+  const startLine = Math.max(0, observation.startLine - 1);
+  const startCharacter = Math.max(0, observation.startCol - 1);
+  const endLine = Math.max(startLine, observation.endLine - 1);
+
+  const rawEndCharacter = Math.max(0, observation.endCol - 1);
+  const endCharacter = endLine === startLine
+    ? Math.max(startCharacter + 1, rawEndCharacter)
+    : rawEndCharacter;
+
+  return new vscode.Range(startLine, startCharacter, endLine, endCharacter);
+}
+
+function mapSeverity(severity: string | undefined): vscode.DiagnosticSeverity {
+  switch (severity) {
+    case "Error":
+      return vscode.DiagnosticSeverity.Error;
+    case "Warning":
+    case "PotentialBug":
+    case "Performance":
+      return vscode.DiagnosticSeverity.Warning;
+    default:
+      return vscode.DiagnosticSeverity.Information;
+  }
+}
+
+function getWorkspaceFolder(): vscode.WorkspaceFolder {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    throw new Error("Plu-Stan requires an open workspace folder.");
+  }
+
+  const active = vscode.window.activeTextEditor
+    ? vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)
+    : undefined;
+
+  return active ?? folders[0];
+}
+
+
+function getWorkspaceFolderOrNotify(): vscode.WorkspaceFolder | undefined {
+  try {
+    return getWorkspaceFolder();
+  } catch (error) {
+    vscode.window.showErrorMessage(`Plu-Stan: ${formatError(error)}`);
+    return undefined;
+  }
+}
+function readSettings(folder: vscode.WorkspaceFolder): PluStanSettings {
+  const config = vscode.workspace.getConfiguration("plustan", folder.uri);
+
+  const binaryPath = config.get<string>("binaryPath", "").trim();
+  const configuredProjectDir = config.get<string>("projectDir", "").trim();
+  const projectDir = configuredProjectDir
+    ? resolveAgainst(folder.uri.fsPath, configuredProjectDir)
+    : folder.uri.fsPath;
+
+  const hieDir = config.get<string>("hieDir", ".hie");
+  const extraArgs = config.get<string[]>("extraArgs", []);
+  const showOutputChannel = config.get<boolean>("showOutputChannel", true);
+
+  return {
+    binaryPath,
+    projectDir,
+    hieDir,
+    extraArgs,
+    showOutputChannel
+  };
+}
+
+function hasConfiguredBinaryPath(settings: PluStanSettings): boolean {
+  return settings.binaryPath.trim().length > 0;
+}
+
+async function ensureBinaryConfigured(
+  folder: vscode.WorkspaceFolder,
+  provider: OnchainModulesProvider
+): Promise<PluStanSettings | undefined> {
+  const settings = readSettings(folder);
+  const configured = hasConfiguredBinaryPath(settings);
+  provider.setBinaryConfigured(configured);
+  if (configured) {
+    return settings;
+  }
+
+  const choice = await vscode.window.showWarningMessage(
+    "Set `plustan.binaryPath` in settings before running Plu-Stan commands.",
+    "Open Settings"
+  );
+  if (choice) {
+    await vscode.commands.executeCommand("plustan.openSettings");
+  }
+  return undefined;
+}
+
+function resolveAgainst(baseDir: string, target: string): string {
+  return path.isAbsolute(target) ? target : path.join(baseDir, target);
+}
+
+async function saveWorkspaceBeforeRun(): Promise<boolean> {
+  const saved = await vscode.workspace.saveAll(false);
+  if (saved) {
+    return true;
+  }
+
+  vscode.window.showWarningMessage(
+    "Plu-Stan: save failed for one or more files. Analysis was cancelled."
+  );
+  return false;
+}
+
+function toRelativePath(workspaceRoot: string, targetPath: string): string {
+  const absoluteTarget = path.isAbsolute(targetPath)
+    ? targetPath
+    : path.join(workspaceRoot, targetPath);
+  return path.relative(workspaceRoot, absoluteTarget) || targetPath;
+}
+
+
+async function runPluStanJson<T>(
+  args: string[],
+  settings: PluStanSettings,
+  output: vscode.OutputChannel,
+  token: vscode.CancellationToken
+): Promise<T> {
+  if (settings.showOutputChannel) {
+    output.show(true);
+  }
+  output.appendLine(`$ ${settings.binaryPath} ${args.join(" ")}`);
+  output.appendLine(`cwd: ${settings.projectDir}`);
+
+  let stdout = "";
+  let stderr = "";
+  let exitCode = 0;
+  try {
+    const result = await spawnCommand(settings.binaryPath, args, settings.projectDir, output, token);
+    stdout = result.stdout;
+    stderr = result.stderr;
+    exitCode = result.exitCode;
+  } catch (error) {
+    if (isEnoentError(error)) {
+      throw new Error(
+        `Plu-Stan binary not found: ${settings.binaryPath}. ` +
+        "Set `plustan.binaryPath` to an existing executable."
+      );
+    }
+    throw error;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseJsonFromOutput(stdout);
+  } catch (error) {
+    const exitSuffix = exitCode !== 0 ? `\nExit code: ${exitCode}` : "";
+    throw new Error(
+      `Failed to parse plustan JSON output: ${formatError(error)}${exitSuffix}\n` +
+      `stderr:\n${stderr}\nstdout:\n${stdout}`
+    );
+  }
+
+  if (exitCode !== 0) {
+    output.appendLine(`Plu-Stan exited with code ${exitCode}; using emitted JSON payload.`);
+  }
+
+  return parsed as T;
+}
+
+function parseJsonFromOutput(stdout: string): unknown {
+  const lines = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    try {
+      return JSON.parse(line);
+    } catch {
+      // Continue scanning earlier lines.
+    }
+  }
+
+  return JSON.parse(stdout);
+}
+
+function appendOnchainModulesSummary(
+  payload: ListOnchainPayload,
+  folder: vscode.WorkspaceFolder,
+  output: vscode.OutputChannel
+): void {
+  output.appendLine(`Plu-Stan modules: ${payload.modules.length} found`);
+  if (payload.modules.length === 0) {
+    return;
+  }
+
+  for (const moduleInfo of payload.modules) {
+    const relPath = toRelativePath(folder.uri.fsPath, moduleInfo.file);
+    output.appendLine(`- ${moduleInfo.moduleName} (${moduleInfo.annotationSource}) ${relPath}`);
+  }
+}
+
+function appendAnalyzeSummary(
+  payload: AnalyzePayload,
+  folder: vscode.WorkspaceFolder,
+  output: vscode.OutputChannel
+): void {
+  const observations = payload.analysis.observations;
+  output.appendLine(
+    `Plu-Stan analysis: runScope=${payload.runScope}, observations=${observations.length}`
+  );
+
+  if (observations.length === 0) {
+    output.appendLine("No observations.");
+    return;
+  }
+
+  const inspections = new Map(payload.inspections.map((inspection) => [inspection.id, inspection]));
+  const maxLines = 200;
+  const toShow = observations.slice(0, maxLines);
+
+  for (const observation of toShow) {
+    const relPath = toRelativePath(folder.uri.fsPath, observation.file);
+    const inspection = inspections.get(observation.inspectionId);
+    const nameSuffix = inspection ? ` ${inspection.name}` : "";
+    output.appendLine(
+      `[${observation.inspectionId}] ${relPath}:${observation.startLine}:${observation.startCol}${nameSuffix}`
+    );
+  }
+
+  if (observations.length > maxLines) {
+    output.appendLine(
+      `... truncated ${observations.length - maxLines} additional observation(s). See Problems panel for full list.`
+    );
+  }
+}
+
+function isEnoentError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const maybeCode = (error as { code?: unknown }).code;
+  return maybeCode === "ENOENT";
+}
+
+function spawnCommand(
+  command: string,
+  args: string[],
+  cwd: string,
+  output: vscode.OutputChannel,
+  token: vscode.CancellationToken
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: process.env
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    const cancelSub = token.onCancellationRequested(() => {
+      child.kill("SIGTERM");
+    });
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      stderr += text;
+      output.append(text);
+    });
+
+    child.on("error", (error) => {
+      cancelSub.dispose();
+      const wrapped = new Error(`Failed to start plustan: ${formatError(error)}`) as Error & { code?: string };
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (errorCode) {
+        wrapped.code = errorCode;
+      }
+      reject(wrapped);
+    });
+
+    child.on("close", (code) => {
+      cancelSub.dispose();
+      resolve({ stdout, stderr, exitCode: code ?? 1 });
+    });
+  });
+}
+
+async function withUserProgress(
+  title: string,
+  action: (token: vscode.CancellationToken) => Promise<void>
+): Promise<void> {
+  try {
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title,
+        cancellable: true
+      },
+      async (_progress, token) => {
+        await action(token);
+      }
+    );
+  } catch (error) {
+    vscode.window.showErrorMessage(`Plu-Stan: ${formatError(error)}`);
+  }
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/vscode-plustan/tsconfig.json
+++ b/vscode-plustan/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": [
+      "ES2022"
+    ],
+    "outDir": "out",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
 ## Summary

  Adds new Plu-Stan anti-pattern rules for incomplete `TxOut` validation, covering cases where code checks several output
  fields but omits one critical field.

  This introduces:

  - `PLU-STAN-13`: missing reference script checks
  - `PLU-STAN-14`: missing staking credential checks
  - `PLU-STAN-15`: missing value checks
  - `PLU-STAN-19`: missing datum checks

  ## What Changed

  - Added new `InspectionAnalysis` constructors and wired them into the analyzer visitor.
  - Added new anti-pattern inspection definitions (`plustan13`, `plustan14`, `plustan15`, `plustan19`) with descriptions/
  solutions/severity.
  - Implemented shared detection logic in `Analyser` for “missing TxOut field” checks, including:
    - field-coverage tracking across address/staking/value/datum/reference,
    - thresholding (warn when multiple fields are validated but one target field is omitted),
    - handling of aliasing and `TxOut` evidence in AST/type info,
    - source-span anchoring for stable observation reporting.
  - Expanded `target/Target/PlutusTx.hs` with a fixture matrix of positive/negative/edge scenarios.
  - Added matching observation-based Hspec coverage in `test/Test/Stan/Analysis/PlutusTx.hs` for all four new rules.

  ## Scope

  - 5 files changed
  - 1098 insertions

  ## Testing

  - Added/updated observation tests under `test/Test/Stan/Analysis/PlutusTx.hs` for PLU-STAN-13/14/15/19.
  - Validation command:
    - `cabal test all --test-show-details=direct`