### PR TITLE
Use gh CLI for releases; bump deps & version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,23 +30,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.1.4
+        run: gh release create ${{ github.ref_name }} --draft --title "Release ${{ github.ref_name }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: true
-          prerelease: false
-
-      - name: Output Release URL File
-        run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
-      - name: Save Release URL File for publish
-        uses: actions/upload-artifact@v3
-        with:
-          name: release_url
-          path: release_url.txt
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_artifact:
     needs: [create_release]
@@ -72,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set tag name
-        uses: olegtarasov/get-tag@v2.1.2
+        uses: olegtarasov/get-tag@v2.1.3
         id: tag
         with:
           tagRegex: "v(.*)"
@@ -111,38 +97,14 @@ jobs:
         run: echo "BINARY_PATH=./dist/stan" >> "$GITHUB_ENV"
 
       - name: Compress binary
-        uses: svenstaro/upx-action@2.3.0
+        uses: svenstaro/upx-action@v2.4.1
         with:
           file: ${{ env.BINARY_PATH }}
 
-      - name: Load Release URL File from release job
-        uses: actions/download-artifact@v3
-        with:
-          name: release_url
-          path: release_url
-
-      # See Note [environment variables]
-      - if: matrix.os == 'windows-latest'
-        name: Get Release File Name & Upload URL on Widows
-        run: |
-          echo "upload_url=$(cat release_url/release_url.txt)" >> $env:GITHUB_ENV
-
-      # See Note [environment variables]
-      - if: matrix.os != 'windows-latest'
-        name: Get Release File Name & Upload URL not on Widows
-        run: |
-          echo "upload_url=$(cat release_url/release_url.txt)" >> $GITHUB_ENV
-
       - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.2
+        run: gh release upload ${{ github.ref_name }} "${{ env.BINARY_PATH }}#stan-${{ steps.tag.outputs.tag }}-${{ runner.os }}-ghc-${{ matrix.ghc }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.upload_url }}
-          asset_path: ${{ env.BINARY_PATH }}
-          asset_name: stan-${{ steps.tag.outputs.tag }}-${{ runner.os }}-ghc-${{ matrix.ghc }}${{ env.EXT }}
-          asset_content_type: application/octet-stream
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_plustan_canonical:
     needs: [create_release]
@@ -174,7 +136,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set tag name
-        uses: olegtarasov/get-tag@v2.1.2
+        uses: olegtarasov/get-tag@v2.1.3
         id: tag
         with:
           tagRegex: "v(.*)"
@@ -201,28 +163,7 @@ jobs:
           mkdir dist
           cabal install exe:plustan --install-method=copy --overwrite-policy=always --installdir=dist
 
-      - name: Load Release URL File from release job
-        uses: actions/download-artifact@v3
-        with:
-          name: release_url
-          path: release_url
-
-      # See Note [environment variables]
-      - if: matrix.os == 'windows-latest'
-        name: Get Upload URL (Windows)
-        run: echo "upload_url=$(cat release_url/release_url.txt)" >> $env:GITHUB_ENV
-
-      # See Note [environment variables]
-      - if: matrix.os != 'windows-latest'
-        name: Get Upload URL (non-Windows)
-        run: echo "upload_url=$(cat release_url/release_url.txt)" >> "$GITHUB_ENV"
-
       - name: Upload plustan canonical asset
-        uses: actions/upload-release-asset@v1.0.2
+        run: gh release upload ${{ github.ref_name }} "./dist/${{ matrix.binary }}#plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}${{ matrix.ext }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.upload_url }}
-          asset_path: ./dist/${{ matrix.binary }}
-          asset_name: plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}${{ matrix.ext }}
-          asset_content_type: application/octet-stream
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,8 @@ jobs:
           cabal install exe:plustan --install-method=copy --overwrite-policy=always --installdir=dist
 
       - name: Upload plustan canonical asset
-        run: gh release upload ${{ github.ref_name }} "./dist/${{ matrix.binary }}#plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}${{ matrix.ext }}"
+        run: |
+          cp "./dist/${{ matrix.binary }}" "./dist/plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}${{ matrix.ext }}"
+          gh release upload ${{ github.ref_name }} "./dist/plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}${{ matrix.ext }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,22 @@ jobs:
         with:
           file: ${{ env.BINARY_PATH }}
 
+      # See Note [environment variables]
+      - if: matrix.os == 'windows-latest'
+        name: Copy binary to unique asset name on Windows
+        run: |
+          Copy-Item "${{ env.BINARY_PATH }}" "./dist/stan-${{ steps.tag.outputs.tag }}-${{ runner.os }}-ghc-${{ matrix.ghc }}.exe"
+          echo "ASSET_PATH=./dist/stan-${{ steps.tag.outputs.tag }}-${{ runner.os }}-ghc-${{ matrix.ghc }}.exe" >> $env:GITHUB_ENV
+
+      # See Note [environment variables]
+      - if: matrix.os != 'windows-latest'
+        name: Copy binary to unique asset name not on Windows
+        run: |
+          cp "${{ env.BINARY_PATH }}" "./dist/stan-${{ steps.tag.outputs.tag }}-${{ runner.os }}-ghc-${{ matrix.ghc }}"
+          echo "ASSET_PATH=./dist/stan-${{ steps.tag.outputs.tag }}-${{ runner.os }}-ghc-${{ matrix.ghc }}" >> "$GITHUB_ENV"
+
       - name: Upload Release Asset
-        run: gh release upload ${{ github.ref_name }} "${{ env.BINARY_PATH }}#stan-${{ steps.tag.outputs.tag }}-${{ runner.os }}-ghc-${{ matrix.ghc }}"
+        run: gh release upload ${{ github.ref_name }} "${{ env.ASSET_PATH }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/vscode-plustan/package-lock.json
+++ b/vscode-plustan/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-plustan",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-plustan",
-      "version": "0.0.8",
+      "version": "0.1.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/node": "^20.14.10",

--- a/vscode-plustan/package.json
+++ b/vscode-plustan/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-plustan",
   "displayName": "Plu-Stan",
   "description": "Security and performance static analysis for Cardano smart contracts written in Plinth.",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "icon": "media/logo.png",
   "publisher": "IOG",
   "license": "MPL-2.0",


### PR DESCRIPTION
Replace actions/create-release and actions/upload-release-asset with gh CLI commands (gh release create / gh release upload) and set GH_TOKEN env to simplify release workflow and remove artifact download/upload steps. Bump olegtarasov/get-tag to v2.1.3 and svenstaro/upx-action to v2.4.1. Also update vscode-plustan package version from 0.0.11 to 0.1.0.