### PR TITLE
chore: post-v0.2.2.0 polish — drop plutus ceiling, extension auto-update, fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,6 @@ jobs:
     needs: [create_release]
     name: plustan / ${{ matrix.target }} / ghc ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        # Use bash on every OS (including the Windows runner's Git bash) so the
-        # build/upload steps below share a single, portable shell.
-        shell: bash
     strategy:
       # Don't fail fast: one GHC/platform leg failing must not stop the others
       # from shipping. Whatever builds gets uploaded; the publish job promotes
@@ -67,6 +62,7 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: "3.12"
+          cabal-update: true
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
@@ -97,24 +93,35 @@ jobs:
       # stack green on windows-latest without them (haskell-actions/setup pulls
       # what's required). So there is no Windows dependency step on purpose.
 
-      - name: Freeze
-        run: cabal freeze
+      # Mirror ci.yml's proven-green solve: configure with tests/benchmarks and
+      # generate plan.json, instead of `cabal freeze`. `cabal freeze` was
+      # failing at the solve step on windows-* (all GHCs) and on 9.12.2 (all
+      # OSes), whereas this exact recipe is green across all 12 os x ghc legs
+      # in ci.yml. The plan.json it produces is the cache key.
+      - name: Configure
+        run: cabal configure --enable-tests --enable-benchmarks
+
+      - name: Generate build plan (for cache key)
+        run: cabal build all --dry-run
 
       - name: Cache ~/.cabal/store
         uses: actions/cache@v4
         with:
           path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-          key: ${{ runner.os }}-${{ matrix.target }}-${{ matrix.ghc }}-plustan-${{ hashFiles('cabal.project.freeze') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-${{ matrix.ghc }}-plustan-${{ hashFiles('dist-newstyle/cache/plan.json') }}
 
       - name: Build plustan binary
-        run: |
-          mkdir -p dist
-          cabal install exe:plustan --install-method=copy --overwrite-policy=always --installdir=dist
+        run: cabal build exe:plustan
 
       - name: Upload plustan asset
+        # bash is needed for $(cabal list-bin ...) and the cp/upload below; the
+        # cabal steps above run on each runner's native shell (matching ci.yml).
+        shell: bash
         run: |
+          mkdir -p dist
+          BIN=$(cabal list-bin exe:plustan)
           ASSET="plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}-ghc${{ matrix.ghc }}${{ matrix.ext }}"
-          cp "./dist/plustan${{ matrix.ext }}" "./dist/${ASSET}"
+          cp "$BIN" "./dist/${ASSET}"
           gh release upload ${{ github.ref_name }} "./dist/${ASSET}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/stan.cabal
+++ b/stan.cabal
@@ -213,8 +213,8 @@ library target
                      , scientific
                      , text
                      , unordered-containers
-                     , plutus-tx ^>=1.54
-                     , plutus-ledger-api ^>=1.54
+                     , plutus-tx >=1.54
+                     , plutus-ledger-api >=1.54
 
   exposed-modules:     Target.AntiPattern
                          Target.AntiPattern.Stan0206

--- a/stan.cabal
+++ b/stan.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                stan
-version:             0.2.2.0
+version:             0.2.3.0
 synopsis:            Haskell STatic ANalyser
 description:
     Stan is a Haskell __ST__atic __AN__alysis CLI tool.

--- a/vscode-plustan/src/downloadManager.ts
+++ b/vscode-plustan/src/downloadManager.ts
@@ -274,22 +274,34 @@ export async function downloadLatest(
   );
 }
 
+/**
+ * Check GitHub for a newer backend binary and offer to download it.
+ *
+ * When `quiet` is true (background/auto checks), stay silent unless a newer
+ * release is actually available — no "already up to date" or error toasts,
+ * just a log line — so the once-a-day startup check never nags the user.
+ */
 export async function checkForUpdates(
   context: vscode.ExtensionContext,
   output: vscode.OutputChannel,
-  ghc: string | null
+  ghc: string | null,
+  quiet = false
 ): Promise<void> {
   const platform = detectPlatform();
   if (!platform) {
-    vscode.window.showWarningMessage("Plu-Stan: auto-download is not supported on this platform.");
+    if (!quiet) {
+      vscode.window.showWarningMessage("Plu-Stan: auto-download is not supported on this platform.");
+    }
     return;
   }
 
   if (!ghc) {
-    vscode.window.showWarningMessage(
-      "Plu-Stan: couldn't detect your project's GHC version (no .hie files found). " +
-      "Build your project first so Plu-Stan can fetch a matching binary."
-    );
+    if (!quiet) {
+      vscode.window.showWarningMessage(
+        "Plu-Stan: couldn't detect your project's GHC version (no .hie files found). " +
+        "Build your project first so Plu-Stan can fetch a matching binary."
+      );
+    }
     return;
   }
 
@@ -300,7 +312,11 @@ export async function checkForUpdates(
     const cachedVersion = getCacheMap(context.globalState)[ghc]?.version;
 
     if (cachedVersion === latestVersion) {
-      vscode.window.showInformationMessage(`Plu-Stan: already up to date (${latestVersion}, GHC ${ghc}).`);
+      if (!quiet) {
+        vscode.window.showInformationMessage(`Plu-Stan: already up to date (${latestVersion}, GHC ${ghc}).`);
+      } else {
+        output.appendLine(`Plu-Stan: up to date (${latestVersion}, GHC ${ghc}).`);
+      }
       return;
     }
 
@@ -316,6 +332,8 @@ export async function checkForUpdates(
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     output.appendLine(`Plu-Stan: update check failed: ${msg}`);
-    vscode.window.showErrorMessage(`Plu-Stan: update check failed — ${msg}`);
+    if (!quiet) {
+      vscode.window.showErrorMessage(`Plu-Stan: update check failed — ${msg}`);
+    }
   }
 }

--- a/vscode-plustan/src/extension.ts
+++ b/vscode-plustan/src/extension.ts
@@ -3,6 +3,10 @@ import { spawn } from "node:child_process";
 import * as vscode from "vscode";
 import { getCachedBinaryPath, offerDownload, checkForUpdates, detectProjectGhc } from "./downloadManager";
 
+// Throttle for the background "newer backend available?" check on activation.
+const LAST_AUTO_UPDATE_CHECK_KEY = "plustan.lastAutoUpdateCheck";
+const AUTO_UPDATE_INTERVAL_MS = 24 * 60 * 60 * 1000; // once per day
+
 type AnnotationSource = "hi" | "source" | "both";
 type RunScope = "all" | "module";
 
@@ -190,6 +194,35 @@ export function activate(context: vscode.ExtensionContext): void {
     return getCachedBinaryPath(context.globalState, ghc) !== undefined;
   };
 
+  // Background, throttled "is there a newer backend?" check. Runs at most once
+  // per AUTO_UPDATE_INTERVAL_MS and only when the extension manages the binary
+  // (no user-set binaryPath) and one is already downloaded — first-time setup
+  // is handled by offerDownload. Quiet: it only surfaces UI when an update
+  // actually exists, so a new backend release reaches users with no extension
+  // republish and no startup nagging.
+  const maybeAutoCheckForUpdates = async (): Promise<void> => {
+    try {
+      const folder = getWorkspaceFolder();
+      const settings = readSettings(folder);
+      if (hasConfiguredBinaryPath(settings)) {
+        return; // user manages their own binary
+      }
+      const ghc = detectProjectGhc(settings.hieDir, settings.projectDir);
+      if (getCachedBinaryPath(context.globalState, ghc) === undefined) {
+        return; // nothing downloaded yet; offerDownload covers that
+      }
+      const last = context.globalState.get<number>(LAST_AUTO_UPDATE_CHECK_KEY, 0);
+      const now = Date.now();
+      if (now - last < AUTO_UPDATE_INTERVAL_MS) {
+        return;
+      }
+      await context.globalState.update(LAST_AUTO_UPDATE_CHECK_KEY, now);
+      await checkForUpdates(context, output, ghc, /* quiet */ true);
+    } catch {
+      // best-effort; never block activation on an update check
+    }
+  };
+
   context.subscriptions.push(output, diagnostics);
   context.subscriptions.push(
     vscode.window.registerTreeDataProvider("plustanOnchainModules", provider)
@@ -329,6 +362,9 @@ export function activate(context: vscode.ExtensionContext): void {
           provider.setBinaryConfigured(true);
         }
       });
+    } else {
+      // Already have a binary — quietly see if a newer backend shipped.
+      void maybeAutoCheckForUpdates();
     }
   } catch {
     provider.setBinaryConfigured(false);


### PR DESCRIPTION
Post-v0.2.2.0 improvements + fix for the failed release legs.

**stan.cabal — drop the plutus ceiling.** Relax the `target` fixtures from `^>=1.54` to `>=1.54`. plustan reads the user's .hie and matches Plutus names (never links plutus), so this only affects what the test fixtures compile against, not what users analyze. Solver still resolves plutus 1.54.0.0 at the pinned index-state — no behavioral change today.

**vscode-plustan — auto-check for backend updates.** Throttled (once/24h) background check on activation: prompts when a newer backend release exists, silent when up to date/offline. Users with their own `binaryPath` are never nagged.

**release.yml — fix windows/9.12.2 legs.** v0.2.2.0 failed at `cabal freeze` on all windows-* and all 9.12.2 legs. Aligned with the green `ci.yml` recipe: dropped job-wide `shell: bash`, added `cabal-update: true`, replaced `cabal freeze` with `cabal configure --enable-tests --enable-benchmarks` + `cabal build all --dry-run` (cache key on plan.json), build via `cabal build exe:plustan` + `cabal list-bin`.

**Version:** stan 0.2.2.0 → 0.2.3.0.

Verified locally: extension compiles; dry-run resolves plutus 1.54.0.0; ci-style build sequence runs clean on GHC 9.6.3. Windows/9.12.2 confirmed only by the v0.2.3.0 release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)