### PR TITLE
fix(release): build plustan plutus-free so windows + 9.12.2 legs succeed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,45 +64,21 @@ jobs:
           cabal-version: "3.12"
           cabal-update: true
 
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update && sudo apt-get install -y libsodium-dev libsecp256k1-dev pkg-config
-          git clone --depth 1 https://github.com/supranational/blst.git /tmp/blst
-          cd /tmp/blst && ./build.sh
-          sudo install -m 644 bindings/blst.h bindings/blst_aux.h /usr/local/include/
-          sudo install -m 644 libblst.a /usr/local/lib/
-          sudo mkdir -p /usr/local/lib/pkgconfig
-          printf 'Name: libblst\nVersion: 0.3\nDescription: BLS12-381 signature library\nLibs: -L/usr/local/lib -lblst\nCflags: -I/usr/local/include\n' | sudo tee /usr/local/lib/pkgconfig/libblst.pc
-          echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}" >> "$GITHUB_ENV"
-
-      - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install libsodium secp256k1
-          git clone --depth 1 https://github.com/supranational/blst.git /tmp/blst
-          cd /tmp/blst && ./build.sh
-          BREW_PREFIX=$(brew --prefix)
-          install -m 644 bindings/blst.h bindings/blst_aux.h "$BREW_PREFIX/include/"
-          install -m 644 libblst.a "$BREW_PREFIX/lib/"
-          mkdir -p "$BREW_PREFIX/lib/pkgconfig"
-          printf "Name: libblst\nVersion: 0.3\nDescription: BLS12-381 signature library\nLibs: -L$BREW_PREFIX/lib -lblst\nCflags: -I$BREW_PREFIX/include\n" > "$BREW_PREFIX/lib/pkgconfig/libblst.pc"
-          echo "PKG_CONFIG_PATH=$BREW_PREFIX/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}" >> "$GITHUB_ENV"
-
-      # Windows needs no manual Cardano system libraries: CI builds the full
-      # stack green on windows-latest without them (haskell-actions/setup pulls
-      # what's required). So there is no Windows dependency step on purpose.
-
-      # Mirror ci.yml's proven-green solve: configure with tests/benchmarks and
-      # generate plan.json, instead of `cabal freeze`. `cabal freeze` was
-      # failing at the solve step on windows-* (all GHCs) and on 9.12.2 (all
-      # OSes), whereas this exact recipe is green across all 12 os x ghc legs
-      # in ci.yml. The plan.json it produces is the cache key.
-      - name: Configure
-        run: cabal configure --enable-tests --enable-benchmarks
+      # The release binary is plutus-free: exe:plustan depends only on `stan` +
+      # the GHC API, never on plutus. Only the `target` test fixtures pull in
+      # plutus / cardano-crypto (and hence the libsodium/secp256k1/blst system
+      # libs). Building with `-f-fixtures` drops `target` from the solve, so:
+      #   * Windows no longer needs libsodium in its pkg-config db (the v0.2.2/
+      #     v0.2.3 windows legs failed on "pkg-config package libsodium ... not
+      #     found"); and
+      #   * GHC 9.12.2 no longer hits the plutus-core 1.54 dead-end (nothunks
+      #     ^>=0.2 caps time <1.13, but 9.12.2 ships boot time 1.14).
+      # No Cardano system libraries are installed anywhere on purpose.
+      - name: Configure (plutus-free; skip target fixtures)
+        run: cabal configure --flags="-fixtures"
 
       - name: Generate build plan (for cache key)
-        run: cabal build all --dry-run
+        run: cabal build exe:plustan --dry-run
 
       - name: Cache ~/.cabal/store
         uses: actions/cache@v4

--- a/stan.cabal
+++ b/stan.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                stan
-version:             0.2.3.0
+version:             0.2.4.0
 synopsis:            Haskell STatic ANalyser
 description:
     Stan is a Haskell __ST__atic __AN__alysis CLI tool.
@@ -38,6 +38,15 @@ flag directory-ospath-streaming
   manual: False
   description:
     Whether to use directory-ospath-streaming. Should be false with 9.6 > ghc.
+
+flag fixtures
+  default: True
+  manual: True
+  description:
+    Build the plutus test fixtures (library target). These pull in plutus-tx /
+    plutus-ledger-api and the Cardano crypto system libraries (libsodium,
+    secp256k1, blst). Disable (-f-fixtures) to build a plutus-free plustan --
+    e.g. for release binaries, which never link plutus. Tests need it ON.
 
 common common-options
   build-depends:       base >= 4.13 && < 4.22 && (< 4.16.3.0 || >= 4.17)
@@ -208,6 +217,8 @@ executable plustan
 library target
   import:              common-options
   hs-source-dirs:      target
+  if !flag(fixtures)
+    buildable: False
   build-depends:       bytestring
                      , filepath
                      , scientific


### PR DESCRIPTION
## Root cause (from the v0.2.2.0/v0.2.3.0 release logs, Cabal-7107)

Every **windows-*** leg and every **9.12.2** leg failed at the solver step:

- **windows:** `cardano-crypto-class` (via plutus-core) has `pkgconfig-depends: libsodium`, absent from the Windows pkg-config database → solver rejects it, no plan.
- **9.12.2:** `plutus-core 1.54` pins `nothunks ^>=0.2`; nothunks 0.2.x caps `time <1.13`; GHC 9.12.2 ships boot `time 1.14` → no plan. (plutus-core 1.54 genuinely can't build on 9.12.2.)

Both stem from one thing: `cabal build --dry-run` solves the **whole project**, so the `target` test fixtures drag plutus + cardano-crypto + libsodium into the solve — even though **`exe:plustan` never links plutus** (only `stan` + the GHC API).

## Fix

Add a manual `fixtures` cabal flag (default **ON**) gating `library target`'s buildability and its plutus deps. The release builds with **`-f-fixtures`**, dropping `target` from the solve → a **plutus-free plan on every platform**. This:

- fixes **windows** (no libsodium needed),
- fixes **9.12.2** (no plutus/nothunks/time conflict),
- lets us **delete** the fragile libsodium/secp256k1/blst install steps.

CI and tests keep the flag ON (default) and are unaffected — the test suite reads the fixtures' `.hie` from disk and doesn't `build-depends: target`.

## Verified locally
`cabal configure --flags=-fixtures` + `cabal build exe:plustan` → **125-pkg plutus-free plan** (vs 322 with plutus), builds, and produces a working plustan. Windows/9.12.2 confirmed only by the release run on the `v0.2.4.0` tag.

**Note:** if a leg still fails, it'll be because `stan` itself (independent of plutus) doesn't solve on that GHC — a separate, one-line matrix trim.

Bump 0.2.3.0 → 0.2.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)