### PR TITLE
chore(release): drop deprecated olegtarasov/get-tag action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v5
 
-      - name: Set tag name
-        uses: olegtarasov/get-tag@v2.1.3
-        id: tag
-        with:
-          tagRegex: "v(.*)"
-          tagRegexGroup: 1
-
       - name: Setup Haskell
         uses: haskell-actions/setup@v2
         id: setup-haskell-cabal
@@ -95,10 +88,11 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
+          VERSION="${GITHUB_REF_NAME#v}"   # tag v0.2.4.0 -> 0.2.4.0
           BIN=$(cabal list-bin exe:plustan)
-          ASSET="plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}-ghc${{ matrix.ghc }}${{ matrix.ext }}"
+          ASSET="plustan-${VERSION}-${{ matrix.target }}-ghc${{ matrix.ghc }}${{ matrix.ext }}"
           cp "$BIN" "./dist/${ASSET}"
-          gh release upload ${{ github.ref_name }} "./dist/${ASSET}"
+          gh release upload "${GITHUB_REF_NAME}" "./dist/${ASSET}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Replaces the Node-20-deprecated `olegtarasov/get-tag@v2.1.3` (used only to strip the leading `v` from the tag) with a built-in bash expansion `${GITHUB_REF_NAME#v}` in the upload step.

- Removes a third-party action + its Node-20 deprecation annotation.
- Asset names unchanged (verified: `v0.2.5.0` → `0.2.5.0`).
- Takes effect on the next backend release; no functional change.

Part of pre-release cleanup. Note: the other build annotations are intentional and were deliberately left — the `target/*` fixtures and `Stan/Example.hs` are purposely-flawed inputs stan analyzes, and the `Stan/Pattern/Type.hs` `baseNameFrom` 'unused import' is a CPP false positive (needed for GHC <9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)