### PR TITLE
feat: VS Code review cockpit (Phase 1) + schema-v2 backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,12 @@ tags
 vscode-plustan/out/
 vscode-plustan/node_modules/
 vscode-plustan/*.vsix
+vscode-plustan/.vscode-test/
+
+# Integration test fixture workspace settings (needed to point the fixture at
+# the fake plustan binary); un-ignore despite the blanket ".vscode/" rule above.
+!vscode-plustan/test-fixtures/workspace/.vscode/
+!vscode-plustan/test-fixtures/workspace/.vscode/settings.json
 
 # Emacs
 *#

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 `stan` uses [PVP Versioning][1].
 The change log is available [on GitHub][2].
 
+## 0.2.5.0
+
+* Add a `plustan capabilities` subcommand: a machine-readable, project-free
+  JSON handshake reporting `schemaVersion`, `ghcVersion`, and the set of
+  supported `features`.
+
+* Bump the `plustan analyze --json` payload to schema v2:
+
+    * Each observation now carries a stable `fingerprint`.
+    * Inspections include documentation fields (`whyItMatters`,
+      `badExample`, `goodExample`, `docsAnchor`) when available.
+    * Observations are now a top-level `observations` array instead of
+      being nested inside an `analysis` field, which has been removed.
+
+* `plustan list-onchain --json` now reports the same schema version as
+  `analyze --json` instead of a hardcoded `1`.
+
 ## 0.2.1.0
 
 * Fix high memory usage in finding Cabal files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 `stan` uses [PVP Versioning][1].
 The change log is available [on GitHub][2].
 
+## vscode-plustan 0.3.0
+
+* Add the review-session cockpit: **Start Review** analyzes the chosen
+  onchain modules (or the whole workspace) and opens a Findings tree grouped
+  by severity/rule (or by module), with a Finding Detail panel that renders
+  each rule's teaching docs — why it matters, a bad/good example pair, and a
+  fix suggestion.
+
+* Persist dismissals to `.plustan/dismissals.json` (with an optional note),
+  so a reviewer's "not applicable" calls survive restarts and can be shared
+  with the team by committing the file.
+
+* Track finding staleness: editing a file marks its open findings stale
+  immediately, and saving an onchain module auto re-runs analysis for it and
+  reconciles fixed / new / still-open findings. A status bar item shows the
+  live open/fixed counts for the session; **End Review** stops auto re-runs
+  and logs a summary.
+
+* Speak schema-v2 to the backend: a `plustan capabilities` handshake gates
+  the session on a compatible binary and offers "Check for Updates" on a
+  mismatch (extension 0.3.x requires `plustan` >= 0.2.5.0).
+
+* Guard the legacy one-shot `Run Workspace` / `Run Module` commands: they
+  are disabled while a review session is active, so they can no longer
+  clobber session diagnostics.
+
+* Expand a leading `${workspaceFolder}` token in `plustan.binaryPath`
+  (VS Code only expands it in `launch.json`/`tasks.json`, not arbitrary
+  settings, so the extension does it itself).
+
 ## 0.2.5.0
 
 * Add a `plustan capabilities` subcommand: a machine-readable, project-free

--- a/RULES.md
+++ b/RULES.md
@@ -150,7 +150,7 @@ isMaybeStakingCredential' b =
 
 ## Value Handling
 
-- **`valueOf` instead of `valueEq` without limits:** Potential Dusk token attack when the number of unique tokens is unbounded. (**Stan:** partially implemented via `PLU-STAN-09` for `valueOf` in boolean comparisons)
+- **`valueOf` instead of `valueEq` without limits:** Potential dust token attack when the number of unique tokens is unbounded. (**Stan:** partially implemented via `PLU-STAN-09` for `valueOf` in boolean comparisons)
 - **`valueOf` with `adaSymbol` and `adaToken`:** Prefer extracting ADA directly. (**Stan:** not implemented)
   ```haskell
   -- BuiltinData variant

--- a/app/PluStan.hs
+++ b/app/PluStan.hs
@@ -40,6 +40,7 @@ import Stan.Info (ProjectInfo (..), StanEnv (..))
 import Stan.Inspection (Inspection (..))
 import Stan.Inspection.All (getInspectionById)
 import Stan.Observation (Observation (..))
+import Stan.Plinth.Payload (analyzeSchemaVersion, mkAnalyzePayload, mkCapabilitiesPayload)
 import Stan.Report (generateReport)
 import Stan.Report.Settings (OutputSettings (..), ToggleSolution (..), Verbosity (..))
 import Stan.Severity (Severity (..))
@@ -81,10 +82,12 @@ runPluStan = do
     Right command -> case command of
       CommandAnalyze analyzeArgs -> runAnalyze analyzeArgs
       CommandListOnchain listArgs -> runListOnchain listArgs
+      CommandCapabilities -> runCapabilities
 
 data PluStanCommand
   = CommandAnalyze AnalyzeArgs
   | CommandListOnchain ListOnchainArgs
+  | CommandCapabilities
 
 data AnalyzeArgs = AnalyzeArgs
   { analyzeReport :: Bool
@@ -141,23 +144,6 @@ instance ToJSON ListOnchainJsonPayload where
     , "modules" .= listPayloadModules
     ]
 
-data AnalyzeJsonPayload = AnalyzeJsonPayload
-  { analyzePayloadVersion :: Int
-  , analyzePayloadRunScope :: Text
-  , analyzePayloadTargetModule :: Maybe ModuleName
-  , analyzePayloadInspections :: [Inspection]
-  , analyzePayloadAnalysis :: Analysis
-  }
-
-instance ToJSON AnalyzeJsonPayload where
-  toJSON AnalyzeJsonPayload{..} = object
-    [ "version" .= analyzePayloadVersion
-    , "runScope" .= analyzePayloadRunScope
-    , "targetModule" .= analyzePayloadTargetModule
-    , "inspections" .= analyzePayloadInspections
-    , "analysis" .= analyzePayloadAnalysis
-    ]
-
 runAnalyze :: AnalyzeArgs -> IO ()
 runAnalyze AnalyzeArgs{..} =
   whenResult_ (finaliseConfig pluStanConfig) $ \warnings config -> do
@@ -191,14 +177,10 @@ runAnalyze AnalyzeArgs{..} =
     let usedInspections = sortOn inspectionId $ map getInspectionById (toList $ analysisInspections analysis)
 
     if analyzeJson
-      then do
-        putJson AnalyzeJsonPayload
-          { analyzePayloadVersion = 1
-          , analyzePayloadRunScope = maybe "all" (const "module") targetModule
-          , analyzePayloadTargetModule = onchainModuleName <$> targetModule
-          , analyzePayloadInspections = usedInspections
-          , analyzePayloadAnalysis = analysis
-          }
+      then putJson $ mkAnalyzePayload
+             (onchainModuleName <$> targetModule)
+             usedInspections
+             (toList observations)
       else do
         if null observations
           then successMessage "All clean! Plu-Stan did not find any observations at the moment."
@@ -231,6 +213,11 @@ runAnalyze AnalyzeArgs{..} =
     getObservationSeverity :: Observation -> Severity
     getObservationSeverity = inspectionSeverity . getInspectionById . observationInspectionId
 
+-- | Machine-readable handshake: always JSON, no project needed.
+runCapabilities :: IO ()
+runCapabilities = putJson $
+  mkCapabilitiesPayload (Text.pack (showVersion compilerVersion))
+
 runListOnchain :: ListOnchainArgs -> IO ()
 runListOnchain ListOnchainArgs{..} = do
   let notJson = not listOnchainJson
@@ -242,7 +229,7 @@ runListOnchain ListOnchainArgs{..} = do
   currentDir <- getCurrentDirectory
   if listOnchainJson
     then putJson ListOnchainJsonPayload
-      { listPayloadVersion = 1
+      { listPayloadVersion = analyzeSchemaVersion
       , listPayloadWorkspaceRoot = currentDir
       , listPayloadHieDir = hieDir
       , listPayloadModules = modules
@@ -265,6 +252,7 @@ usage = Text.unlines
   , "  plustan [--report] [--browse] [--json] [--module MODULE] [--project DIR] [--hiedir DIR] [PROJECT_DIR]"
   , "  plustan analyze [--report] [--browse] [--json] [--module MODULE] [--project DIR] [--hiedir DIR]"
   , "  plustan list-onchain [--json] [--project DIR] [--hiedir DIR]"
+  , "  plustan capabilities            Print JSON schema/feature handshake"
   , ""
   , "Options:"
   , "  --report        Generate stan.html report (analyze only)"
@@ -280,6 +268,7 @@ parsePluStanCommand = \case
   [] -> CommandAnalyze <$> parseAnalyzeArgs True defaultAnalyzeArgs []
   "analyze":rest -> CommandAnalyze <$> parseAnalyzeArgs False defaultAnalyzeArgs rest
   "list-onchain":rest -> CommandListOnchain <$> parseListOnchainArgs defaultListOnchainArgs rest
+  "capabilities":_ -> Right CommandCapabilities
   "help":_ -> Left "help"
   "--help":_ -> Left "help"
   "-h":_ -> Left "help"

--- a/app/PluStan.hs
+++ b/app/PluStan.hs
@@ -40,7 +40,8 @@ import Stan.Info (ProjectInfo (..), StanEnv (..))
 import Stan.Inspection (Inspection (..))
 import Stan.Inspection.All (getInspectionById)
 import Stan.Observation (Observation (..))
-import Stan.Plinth.Payload (analyzeSchemaVersion, mkAnalyzePayload, mkCapabilitiesPayload)
+import Stan.Plinth.Payload (analyzeSchemaVersion, dedupeObservations, mkAnalyzePayload,
+                            mkCapabilitiesPayload)
 import Stan.Report (generateReport)
 import Stan.Report.Settings (OutputSettings (..), ToggleSolution (..), Verbosity (..))
 import Stan.Severity (Severity (..))
@@ -172,6 +173,7 @@ runAnalyze AnalyzeArgs{..} =
     analysis <- getAnalysis (stanArgs hieDir) notJson config filteredHieFiles
       >>= pure . filterAnalysisToContracts (Set.fromList $ map onchainModuleFile onchainModules)
       >>= pure . maybe id (limitAnalysisToTarget . onchainModuleFile) targetModule
+      >>= pure . dedupeAnalysisObservations
 
     let observations = analysisObservations analysis
     let usedInspections = sortOn inspectionId $ map getInspectionById (toList $ analysisInspections analysis)
@@ -571,6 +573,27 @@ limitAnalysisToTarget targetFile analysis = analysis
   { analysisObservations = Slist.filter ((== targetFile) . observationFile) (analysisObservations analysis)
   , analysisFileMap = Map.filterWithKey (\filePath _ -> filePath == targetFile) (analysisFileMap analysis)
   }
+
+{- | Collapse observations that report the identical (rule, span) more
+than once (see 'dedupeObservations'), across both the flat
+'analysisObservations' list and each file's 'fileInfoObservations'.
+Applied once, right after the analysis is assembled and filtered, so
+the pretty ('prettyShowAnalysis', which reads 'analysisFileMap') and
+JSON ('mkAnalyzePayload', which reads 'analysisObservations') output
+paths agree on the same deduped observation count instead of the JSON
+side silently deduping while the CLI text output still shows the
+inflated one.
+-}
+dedupeAnalysisObservations :: Analysis -> Analysis
+dedupeAnalysisObservations analysis = analysis
+  { analysisObservations = Slist.slist $ dedupeObservations $ toList $ analysisObservations analysis
+  , analysisFileMap = fmap dedupeFileInfo (analysisFileMap analysis)
+  }
+  where
+    dedupeFileInfo :: FileInfo -> FileInfo
+    dedupeFileInfo fi = fi
+      { fileInfoObservations = Slist.slist $ dedupeObservations $ toList $ fileInfoObservations fi
+      }
 
 generatePluStanReport
   :: AnalyzeArgs

--- a/docs/superpowers/plans/2026-07-06-vscode-review-cockpit-phase1.md
+++ b/docs/superpowers/plans/2026-07-06-vscode-review-cockpit-phase1.md
@@ -1,0 +1,2586 @@
+# Plu-Stan Review Cockpit — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the vscode-plustan MVP into a review-session cockpit: JSON schema v2 with stable fingerprints and rule docs in the backend; session state machine, findings tree, detail panel, dismissals, staleness, and auto-rerun-on-save in the extension.
+
+**Architecture:** The Haskell CLI stays a stateless spawn-per-request analyzer; all new payload assembly lives in testable library modules (`Stan.Plinth.*`). The TypeScript extension is restructured around a vscode-free `core/` (pure reducers, parsers — unit-tested with mocha) and a thin vscode-coupled shell (controller, tree, webview, diagnostics). All analyzer traffic goes through one `AnalyzerClient` interface.
+
+**Tech Stack:** Haskell (GHC 9.6.x, cabal, hspec, microaeson, relude prelude in `src/`), TypeScript 5.5 / VS Code extension API 1.90, mocha for unit tests, @vscode/test-electron for one integration smoke test.
+
+**Spec:** `docs/superpowers/specs/2026-07-06-vscode-review-cockpit-design.md`
+
+**Branch:** all work happens on `feature/vscode-review-cockpit` (already created; the spec is committed there).
+
+---
+
+## Context for a fresh engineer
+
+- The repo is a fork of kowainik/stan. The `plustan` executable is `app/PluStan.hs` (cabal stanza `executable plustan`, `stan.cabal:198`). There is also `executable stan` (upstream CLI) — do not touch it.
+- `src/` modules use the **relude** prelude (via the cabal `common-relude` mixin): `Text`, `HashMap`, `fromList`, `toList`, `sortOn`, `foldl'`, `NonEmpty` are in scope unqualified; partial `head/init/last` on lists are not available.
+- JSON is **microaeson** (`Data.Aeson.Micro`), not aeson: it has `Value`, `object`, `(.=)`, `encode`, `ToJSON`. Its `Object` is a `Map`, so `encode` output has **alphabetically sorted keys** (deterministic — good for golden tests). There is no `FromJSON`/decoding.
+- Backend tests: hspec, entry `test/Spec.hs` (suite `stan-test`). `test/Spec.hs` builds `.hie` files for the repo itself on first run (slow once, then cached). Run with `cabal test` (needs `secp256k1`, `sodium`, `blst` installed — the dev machine has them).
+- The extension is `vscode-plustan/` (TypeScript, `tsc` only, `rootDir: src`, `outDir: out`, currently two files: `extension.ts` 901 lines, `downloadManager.ts`). It currently reads schema-v1 payloads: `analyze --json` → `{version:1, inspections, analysis:{observations}}`.
+- The current v1 `Observation` JSON id (`OBS-PLU-STAN-XX-<hash6>-line:col`, built by `mkObservationId` in `src/Stan/Observation.hs:269`) embeds line:col — that is exactly what fingerprints replace for identity purposes.
+- `Observation` carries the **full source file** in `observationFileContent :: ByteString`, and the flagged span in `observationSrcSpan :: RealSrcSpan` (accessors `srcSpanStartLine/StartCol/EndLine/EndCol` from `Stan.Ghc.Compat`). GHC end columns are exclusive (one past the last character).
+
+## File structure
+
+**Backend — create:**
+- `src/Stan/Plinth/Docs.hs` — per-rule teaching content (`InspectionDocs`, `lookupDocs`)
+- `src/Stan/Plinth/Payload.hs` — schema-v2 payload assembly (pure, golden-testable)
+- `test/Test/Stan/Plinth.hs` — hspec specs for both new modules
+
+**Backend — modify:**
+- `src/Stan/Observation.hs` — add `observationSpanText`, `observationFingerprint`, generalize `hashModuleName`
+- `test/Test/Stan/Observation.hs` — fingerprint specs
+- `app/PluStan.hs` — `capabilities` subcommand, emit v2 analyze payload
+- `stan.cabal` — expose new modules, add test module, bump version to `0.2.5.0`
+- `test/Spec.hs` — register new spec
+- `CHANGELOG.md`
+
+**Extension — create (under `vscode-plustan/src/`):**
+- `core/schema.ts` — v2 payload types + validation (no vscode imports)
+- `core/schema.test.ts`
+- `core/sessionState.ts` — pure session reducer (no vscode imports)
+- `core/sessionState.test.ts`
+- `core/dismissals.ts` — pure dismissals-file logic (no vscode imports)
+- `core/dismissals.test.ts`
+- `core/runCoalescer.ts` — pending-run queue logic (no vscode imports)
+- `core/runCoalescer.test.ts`
+- `analyzer/client.ts` — `AnalyzerClient` + `SpawnAnalyzerClient` (no vscode imports; uses `AbortSignal`)
+- `analyzer/client.test.ts`
+- `session/controller.ts` — vscode-coupled orchestration
+- `session/dismissalsStore.ts` — vscode-coupled file I/O for `.plustan/dismissals.json`
+- `ui/findingsTree.ts`, `ui/detailPanel.ts`, `ui/statusBar.ts`
+- `diagnostics.ts` — session-state → DiagnosticCollection + dismiss code action
+- `test/runTest.ts`, `test/suite/index.ts`, `test/suite/session.test.ts` — integration smoke
+
+**Extension — create (outside `src/`):**
+- `vscode-plustan/test-fixtures/fake-plustan.js`, `test-fixtures/fake-plustan` (shim), `test-fixtures/workspace/` — stub binary + fixture workspace
+
+**Extension — modify:**
+- `src/extension.ts` — becomes thin wiring; spawn/JSON plumbing moves to `analyzer/client.ts`
+- `package.json` — views, commands, menus, scripts, devDependencies, version 0.3.0
+- `README.md`, `MARKETPLACE.md`
+
+**Hard rule:** files under `core/` and `analyzer/` MUST NOT import `vscode`. That is what makes them mocha-testable without an extension host.
+
+---
+
+### Task 1: Observation fingerprints (backend)
+
+**Files:**
+- Modify: `src/Stan/Observation.hs`
+- Test: `test/Test/Stan/Observation.hs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the whole body of `test/Test/Stan/Observation.hs` with (the existing `observationSpec` id test is kept):
+
+```haskell
+module Test.Stan.Observation
+    ( observationSpec
+    ) where
+
+import Stan.Ghc.Compat (mkRealSrcLoc, mkRealSrcSpan)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldNotBe)
+
+import Stan.Core.Id (Id (..))
+import Stan.Inspection (inspectionId)
+import Stan.Inspection.Partial (stan0001)
+import Stan.Observation (Observation (..), mkObservationId, observationFingerprint,
+                         observationSpanText)
+
+import qualified Data.ByteString.Char8 as BS8
+
+
+observationSpec :: Spec
+observationSpec = describe "Observation" $ do
+    it "calculates Observation Id properly" $
+        testObservationId `shouldBe` Id "OBS-STAN-0001-bbjjJQ-10:42"
+
+    describe "observationSpanText" $ do
+        -- line 2 is "bad expr here"; cols 5–14 (GHC end col is exclusive)
+        -- select the 9 characters "expr here"
+        it "extracts a single-line span, column-trimmed" $
+            observationSpanText (mkObs 2 5 14 sampleContent)
+                `shouldBe` "expr here"
+        it "extracts a multi-line span" $
+            observationSpanText (mkObs2 2 5 3 6 sampleContent)
+                `shouldBe` "expr here\ny = 2"
+
+    describe "observationFingerprint" $ do
+        it "is stable when the same flagged text moves to another line" $
+            observationFingerprint (mkObs 2 5 14 sampleContent)
+                `shouldBe` observationFingerprint (mkObs 3 5 14 shiftedContent)
+        it "changes when the flagged text changes" $
+            observationFingerprint (mkObs 2 5 14 sampleContent)
+                `shouldNotBe` observationFingerprint (mkObs 2 5 14 editedContent)
+  where
+    testObservationId :: Id Observation
+    testObservationId = mkObservationId
+        (inspectionId stan0001)
+        "Test.Module.Name"
+        $ mkRealSrcSpan
+            (mkRealSrcLoc "src/Test/Module/Name.hs" 10 42)
+            (mkRealSrcLoc "src/Test/Module/Name.hs" 10 42)
+
+    -- line 1: "x = 1", line 2: "bad expr here", line 3: "y = 2"
+    sampleContent, shiftedContent, editedContent :: ByteString
+    sampleContent  = BS8.pack "x = 1\nbad expr here\ny = 2\n"
+    -- same flagged text, one line lower (a comment was added above)
+    shiftedContent = BS8.pack "-- c\nx = 1\nbad expr here\ny = 2\n"
+    -- the flagged text itself changed
+    editedContent  = BS8.pack "x = 1\nbad EXPR here\ny = 2\n"
+
+    mkObs :: Int -> Int -> Int -> ByteString -> Observation
+    mkObs line startC endC = mkObs2 line startC line endC
+
+    mkObs2 :: Int -> Int -> Int -> Int -> ByteString -> Observation
+    mkObs2 startL startC endL endC content = Observation
+        { observationId = Id "test-obs"
+        , observationInspectionId = inspectionId stan0001
+        , observationSrcSpan = mkRealSrcSpan
+            (mkRealSrcLoc "src/T.hs" startL startC)
+            (mkRealSrcLoc "src/T.hs" endL endC)
+        , observationFile = "src/T.hs"
+        , observationModuleName = "Test.Module.Name"
+        , observationFileContent = content
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+Run: `cabal build stan-test 2>&1 | tail -20`
+Expected: error — `observationFingerprint`/`observationSpanText` not exported from `Stan.Observation`.
+
+- [ ] **Step 3: Implement in `src/Stan/Observation.hs`**
+
+Add `observationFingerprint` and `observationSpanText` to the module export list. Generalize the hash helper (bottom of file, next to `hashModuleName`):
+
+```haskell
+-- | SHA1 + base64, truncated to @n@ characters.
+hashText :: Int -> Text -> Text
+hashText n =
+    Text.take n
+    . extractBase64
+    . Base64.encodeBase64
+    . SHA1.hash
+    . encodeUtf8
+
+hashModuleName :: ModuleName -> Text
+hashModuleName = hashText 6 . unModuleName
+```
+
+Add (near `mkObservationId`):
+
+```haskell
+{- | The source text of the flagged span, column-trimmed on the first
+and last line. GHC end columns are exclusive. Missing lines (file
+content shorter than the span) contribute @""@.
+-}
+observationSpanText :: Observation -> Text
+observationSpanText Observation{..} =
+    Text.intercalate "\n" (trimCols spanLines)
+  where
+    startL, endL, startC, endC :: Int
+    startL = srcSpanStartLine observationSrcSpan
+    endL   = srcSpanEndLine observationSrcSpan
+    startC = srcSpanStartCol observationSrcSpan
+    endC   = srcSpanEndCol observationSrcSpan
+
+    spanLines :: [Text]
+    spanLines =
+        [ maybe "" decodeUtf8 (BS.lines observationFileContent !!? (ln - 1))
+        | ln <- [startL .. endL]
+        ]
+
+    trimCols :: [Text] -> [Text]
+    trimCols [] = []
+    trimCols [single] =
+        [Text.take (endC - startC) (Text.drop (startC - 1) single)]
+    trimCols (firstLine : rest) =
+        Text.drop (startC - 1) firstLine : trimLast rest
+
+    trimLast :: [Text] -> [Text]
+    trimLast [] = []
+    trimLast [lastLine] = [Text.take (endC - 1) lastLine]
+    trimLast (l : ls) = l : trimLast ls
+
+{- | Position-independent identity for an 'Observation':
+
+@
+FPR-<INSPECTION-ID>-<module-hash-6>-<span-text-hash-10>
+@
+
+Stable under edits elsewhere in the file; changes when the flagged
+expression itself changes (which correctly forces re-triage).
+-}
+observationFingerprint :: Observation -> Text
+observationFingerprint o = Text.intercalate "-"
+    [ "FPR"
+    , unId (observationInspectionId o)
+    , hashModuleName (observationModuleName o)
+    , hashText 10 (observationSpanText o)
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cabal test --test-show-details=direct 2>&1 | tail -30`
+Expected: all `Observation` specs PASS (first run may take minutes while `.hie` files build).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Stan/Observation.hs test/Test/Stan/Observation.hs
+git commit -m "feat(backend): position-independent observation fingerprints"
+```
+
+---
+
+### Task 2: Plinth rule docs module (backend)
+
+**Files:**
+- Create: `src/Stan/Plinth/Docs.hs`
+- Create: `test/Test/Stan/Plinth.hs`
+- Modify: `stan.cabal` (library `exposed-modules`, test-suite `other-modules`), `test/Spec.hs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/Test/Stan/Plinth.hs`:
+
+```haskell
+module Test.Stan.Plinth
+    ( plinthSpec
+    ) where
+
+import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, shouldSatisfy)
+
+import Stan.Core.Id (Id (..))
+import Stan.Inspection.All (inspectionsMap)
+import Stan.Plinth.Docs (InspectionDocs (..), lookupDocs)
+
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as Text
+
+
+plinthSpec :: Spec
+plinthSpec = describe "Stan.Plinth.Docs" $ do
+    it "covers every PLU-STAN inspection" $ do
+        let plinthIds = filter (Text.isPrefixOf "PLU-STAN" . unId) (HM.keys inspectionsMap)
+        let missing = filter (isNothing . lookupDocs) plinthIds
+        missing `shouldBe` []
+    it "has non-empty teaching content everywhere" $
+        case lookupDocs (Id "PLU-STAN-04") of
+            Nothing -> expectationFailure "no docs for PLU-STAN-04"
+            Just InspectionDocs{..} -> do
+                docsWhyItMatters `shouldSatisfy` (not . Text.null)
+                docsBadExample `shouldSatisfy` (not . Text.null)
+                docsGoodExample `shouldSatisfy` (not . Text.null)
+```
+
+Register it: in `test/Spec.hs` add `import Test.Stan.Plinth (plinthSpec)` next to the other `Test.Stan.*` imports, and add `plinthSpec` to the `hspec $ do` block (after `observationSpec`). In `stan.cabal` add `Test.Stan.Plinth` to the `stan-test` `other-modules` list.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cabal build stan-test 2>&1 | tail -5`
+Expected: error — `Stan.Plinth.Docs` not found.
+
+- [ ] **Step 3: Create `src/Stan/Plinth/Docs.hs`**
+
+Add `Stan.Plinth.Docs` to the library `exposed-modules` in `stan.cabal` (the list starting at `stan.cabal:101`; insert alphabetically, after the `Stan.Pattern.*` entries and before `Stan.Report`). Module skeleton with the first entry written out in full:
+
+```haskell
+{- |
+Copyright: (c) 2026 IOHK
+SPDX-License-Identifier: MPL-2.0
+
+Teaching content for the PLU-STAN inspections, rendered by the
+VS Code extension's finding detail panel. The analyzer binary is the
+single source of truth for this content — the extension only renders it.
+-}
+
+module Stan.Plinth.Docs
+    ( InspectionDocs (..)
+    , lookupDocs
+    , plinthDocsMap
+    ) where
+
+import Stan.Core.Id (Id (..))
+import Stan.Inspection (Inspection)
+
+import qualified Data.HashMap.Strict as HM
+
+
+-- | Extended, Plinth-specific documentation for one inspection.
+data InspectionDocs = InspectionDocs
+    { docsWhyItMatters :: !Text
+      -- ^ The on-chain rationale: what goes wrong and who exploits it.
+    , docsBadExample   :: !Text
+      -- ^ A short Haskell snippet showing the flagged pattern.
+    , docsGoodExample  :: !Text
+      -- ^ The corrected version of the same snippet.
+    , docsAnchor       :: !Text
+      -- ^ Anchor into RULES.md (e.g. \"equality\"); @\"\"@ if none.
+    } deriving stock (Show, Eq)
+
+lookupDocs :: Id Inspection -> Maybe InspectionDocs
+lookupDocs insId = HM.lookup insId plinthDocsMap
+
+plinthDocsMap :: HashMap (Id Inspection) InspectionDocs
+plinthDocsMap = fromList
+    [ ( Id "PLU-STAN-04"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "Comparing only a PubKeyHash, ScriptHash, or Credential checks the payment"
+              , "part of an address and ignores the staking part. An attacker can construct"
+              , "an output that passes the credential check while redirecting the staking"
+              , "rewards of the locked value to their own stake key — staking value theft."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- only the payment credential is compared"
+              , "paysToOwner out = addressCredential (txOutAddress out) == ownerCredential"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- the full Address (payment + staking) is compared"
+              , "paysToOwner out = txOutAddress out == ownerAddress"
+              ]
+          , docsAnchor = "equality"
+          }
+      )
+    -- … one entry per PLU-STAN rule, see Step 3a …
+    ]
+```
+
+(`Text.unlines` needs `import qualified Data.Text as Text`; add it.)
+
+- [ ] **Step 3a: Fill in the remaining rules**
+
+Add an entry for **every** inspection ID that the completeness test discovers (all `PLU-STAN-*` in `inspectionsMap` — currently 01–12 and 16, plus any added since; also 13/14/15 pattern-rules if present in `antiPatternInspectionsMap`, check `src/Stan/Inspection/AntiPattern.hs`). Content sources, in priority order:
+
+1. The rule's section in `RULES.md` (repo root) — `docsAnchor` is that section's GitHub heading anchor. Mapping of rule → RULES.md section: 02, 10 → *Data Handling & Deserialization* (`data-handling--deserialization`); 09, 11 → *Value Handling* (`value-handling`); 04 → *Equality* (`equality`); 03 → *Optional Types* (`optional-types`); 05, 06 → *Higher-Order Functions* (`higher-order-functions`); 08 → *Bindings* (`bindings`); 07 → *Guards* (`guards`); 16 → *Integers* (`integers`); 12 → *Validity Interval / POSIX Time Misuse* (`validity-interval--posix-time-misuse`).
+2. The rule's row in the README.md rules table and its `descriptionL`/`solutionL` text in `src/Stan/Inspection/AntiPattern.hs` — paraphrase into `docsWhyItMatters`.
+3. For rules with no RULES.md section (e.g. 01): write `docsWhyItMatters` from the inspection's description and solutions, invent a minimal bad/good snippet from the names the rule matches (they are listed in the rule's `NameMeta` values in `AntiPattern.hs`), and set `docsAnchor = ""`.
+
+Every entry must have non-empty `docsWhyItMatters`, `docsBadExample`, `docsGoodExample` (the shape shown for PLU-STAN-04 above). No entry may be a stub.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cabal test --test-show-details=direct 2>&1 | tail -20`
+Expected: `Stan.Plinth.Docs` specs PASS (completeness test proves no rule was skipped).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Stan/Plinth/Docs.hs test/Test/Stan/Plinth.hs test/Spec.hs stan.cabal
+git commit -m "feat(backend): per-rule Plinth teaching docs for the detail panel"
+```
+
+---
+
+### Task 3: Schema-v2 payload assembly (backend)
+
+**Files:**
+- Create: `src/Stan/Plinth/Payload.hs`
+- Modify: `stan.cabal` (add exposed module), `test/Test/Stan/Plinth.hs`
+
+- [ ] **Step 1: Write the failing tests** (append inside `plinthSpec`'s `describe` — or add a sibling `describe "Stan.Plinth.Payload"`):
+
+```haskell
+import Data.Aeson.Micro (Value (..), encode, object, (.=))
+import Stan.Ghc.Compat (mkRealSrcLoc, mkRealSrcSpan)
+import Stan.Inspection.Partial (stan0001)
+import Stan.Inspection (inspectionId)
+import Stan.Observation (Observation (..))
+import Stan.Plinth.Payload (mkAnalyzePayload, mkCapabilitiesPayload, uniquifyFingerprints)
+
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+
+payloadSpec :: Spec
+payloadSpec = describe "Stan.Plinth.Payload" $ do
+    it "capabilities carries schemaVersion 2" $
+        mkCapabilitiesPayload "9.6.6" `shouldBe` object
+            [ "schemaVersion" .= (2 :: Int)
+            , "ghcVersion" .= ("9.6.6" :: Text)
+            , "features" .= (["list-onchain", "analyze", "fingerprints", "inspection-docs"] :: [Text])
+            ]
+    it "suffixes duplicate fingerprints in span order" $ do
+        let content = BS8.pack "f x\nf x\n"      -- identical flagged text on 2 lines
+        let o1 = mkPayloadObs 1 content
+        let o2 = mkPayloadObs 2 content
+        let fps = map snd (uniquifyFingerprints [o2, o1])   -- input deliberately unordered
+        case fps of
+            [fp1, fp2] -> do
+                fp2 `shouldBe` (fp1 <> "#2")
+            _ -> expectationFailure "expected exactly two fingerprints"
+    it "analyze payload is version 2 with top-level observations" $ do
+        let payloadText = LBS8.unpack (encode (mkAnalyzePayload Nothing [] []))
+        payloadText `shouldSatisfy` isInfixOf "\"version\":2"
+        payloadText `shouldSatisfy` isInfixOf "\"observations\":[]"
+  where
+    mkPayloadObs :: Int -> ByteString -> Observation
+    mkPayloadObs line content = Observation
+        { observationId = Id ("obs-" <> show line)
+        , observationInspectionId = inspectionId stan0001
+        , observationSrcSpan = mkRealSrcSpan
+            (mkRealSrcLoc "src/T.hs" line 1)
+            (mkRealSrcLoc "src/T.hs" line 4)
+        , observationFile = "src/T.hs"
+        , observationModuleName = "Test.Module.Name"
+        , observationFileContent = content
+        }
+```
+
+Export `plinthSpec` so it runs both describes (wrap: `plinthSpec = docsSpec >> payloadSpec` or list both under one `describe`). Register nothing new in Spec.hs (already registered in Task 2).
+
+- [ ] **Step 2: Verify compile failure**
+
+Run: `cabal build stan-test 2>&1 | tail -5`
+Expected: `Stan.Plinth.Payload` not found.
+
+- [ ] **Step 3: Create `src/Stan/Plinth/Payload.hs`** (and add to `exposed-modules` in `stan.cabal`):
+
+```haskell
+{- |
+Copyright: (c) 2026 IOHK
+SPDX-License-Identifier: MPL-2.0
+
+Assembly of the machine-readable (schema v2) payloads emitted by the
+@plustan@ CLI for the VS Code extension. Kept in the library so the
+JSON shape is golden-testable.
+-}
+
+module Stan.Plinth.Payload
+    ( analyzeSchemaVersion
+    , mkAnalyzePayload
+    , mkCapabilitiesPayload
+    , uniquifyFingerprints
+    ) where
+
+import Data.Aeson.Micro (Value, object, (.=))
+
+import Stan.Core.ModuleName (ModuleName)
+import Stan.Ghc.Compat (srcSpanEndCol, srcSpanEndLine, srcSpanStartCol, srcSpanStartLine)
+import Stan.Inspection (Inspection (..))
+import Stan.Observation (Observation (..), observationFingerprint)
+import Stan.Plinth.Docs (InspectionDocs (..), lookupDocs)
+
+import qualified Data.HashMap.Strict as HM
+
+
+-- | Version of the JSON contract between the CLI and the extension.
+analyzeSchemaVersion :: Int
+analyzeSchemaVersion = 2
+
+mkCapabilitiesPayload :: Text -> Value
+mkCapabilitiesPayload ghcVersion = object
+    [ "schemaVersion" .= analyzeSchemaVersion
+    , "ghcVersion" .= ghcVersion
+    , "features" .= (["list-onchain", "analyze", "fingerprints", "inspection-docs"] :: [Text])
+    ]
+
+mkAnalyzePayload :: Maybe ModuleName -> [Inspection] -> [Observation] -> Value
+mkAnalyzePayload targetModule inspections observations = object
+    [ "version" .= analyzeSchemaVersion
+    , "runScope" .= maybe ("all" :: Text) (const "module") targetModule
+    , "targetModule" .= targetModule
+    , "inspections" .= map inspectionToJson inspections
+    , "observations" .= map observationToJson (uniquifyFingerprints observations)
+    ]
+
+{- | Pair each observation with a run-unique fingerprint: duplicates
+(same rule, same module, same flagged text) get @#2@, @#3@… suffixes
+in span order, so dismissing one of two identical findings never
+dismisses both.
+-}
+uniquifyFingerprints :: [Observation] -> [(Observation, Text)]
+uniquifyFingerprints observations =
+    reverse $ fst $ foldl' step ([], HM.empty) sorted
+  where
+    sorted :: [Observation]
+    sorted = sortOn spanKey observations
+
+    spanKey :: Observation -> (FilePath, Int, Int)
+    spanKey o =
+        ( observationFile o
+        , srcSpanStartLine (observationSrcSpan o)
+        , srcSpanStartCol (observationSrcSpan o)
+        )
+
+    step
+        :: ([(Observation, Text)], HashMap Text Int)
+        -> Observation
+        -> ([(Observation, Text)], HashMap Text Int)
+    step (acc, seen) o =
+        let base = observationFingerprint o
+            n = HM.lookupDefault 0 base seen + 1
+            fp = if n == 1 then base else base <> "#" <> show n
+        in ((o, fp) : acc, HM.insert base n seen)
+
+inspectionToJson :: Inspection -> Value
+inspectionToJson Inspection{..} = object $
+    [ "id" .= inspectionId
+    , "name" .= inspectionName
+    , "description" .= inspectionDescription
+    , "solution" .= inspectionSolution
+    , "category" .= toList inspectionCategory
+    , "severity" .= inspectionSeverity
+    ] <> docsPairs
+  where
+    docsPairs = case lookupDocs inspectionId of
+        Nothing -> []
+        Just InspectionDocs{..} ->
+            [ "whyItMatters" .= docsWhyItMatters
+            , "badExample" .= docsBadExample
+            , "goodExample" .= docsGoodExample
+            , "docsAnchor" .= docsAnchor
+            ]
+
+observationToJson :: (Observation, Text) -> Value
+observationToJson (Observation{..}, fingerprint) = object
+    [ "id" .= observationId
+    , "inspectionId" .= observationInspectionId
+    , "fingerprint" .= fingerprint
+    , "startLine" .= srcSpanStartLine observationSrcSpan
+    , "startCol" .= srcSpanStartCol observationSrcSpan
+    , "endLine" .= srcSpanEndLine observationSrcSpan
+    , "endCol" .= srcSpanEndCol observationSrcSpan
+    , "file" .= toText observationFile
+    , "moduleName" .= observationModuleName
+    ]
+```
+
+Note: v1's `srcSpan` display string is intentionally dropped — the extension never used it.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cabal test --test-show-details=direct 2>&1 | tail -20`
+Expected: payload specs PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Stan/Plinth/Payload.hs test/Test/Stan/Plinth.hs stan.cabal
+git commit -m "feat(backend): schema-v2 payload assembly with unique fingerprints"
+```
+
+---
+
+### Task 4: Wire `capabilities` + v2 payload into the CLI
+
+**Files:**
+- Modify: `app/PluStan.hs`, `stan.cabal:3` (version), `CHANGELOG.md`
+
+- [ ] **Step 1: Add the subcommand and switch the analyze payload**
+
+In `app/PluStan.hs`:
+
+1. Imports: add `import Stan.Plinth.Payload (analyzeSchemaVersion, mkAnalyzePayload, mkCapabilitiesPayload)`.
+2. Extend the command type and parser (`parsePluStanCommand`, `app/PluStan.hs:278`):
+
+```haskell
+data PluStanCommand
+  = CommandAnalyze AnalyzeArgs
+  | CommandListOnchain ListOnchainArgs
+  | CommandCapabilities
+```
+
+and add the branch **before** the fallback positional case:
+
+```haskell
+  "capabilities":_ -> Right CommandCapabilities
+```
+
+3. Dispatch in `runPluStan`:
+
+```haskell
+      CommandCapabilities -> runCapabilities
+```
+
+4. Add:
+
+```haskell
+-- | Machine-readable handshake: always JSON, no project needed.
+runCapabilities :: IO ()
+runCapabilities = putJson $
+  mkCapabilitiesPayload (Text.pack (showVersion compilerVersion))
+```
+
+5. In `runAnalyze` (`app/PluStan.hs:193`), replace the `putJson AnalyzeJsonPayload {..}` block with:
+
+```haskell
+      then putJson $ mkAnalyzePayload
+             (onchainModuleName <$> targetModule)
+             usedInspections
+             (toList observations)
+```
+
+(`observations` is an `Slist`; `Data.Foldable.toList` is already imported.) Delete the now-unused `AnalyzeJsonPayload` type and its `ToJSON` instance.
+
+6. In `runListOnchain`, change `listPayloadVersion = 1` to `listPayloadVersion = analyzeSchemaVersion` (the list shape didn't change, but a single schema number for the whole CLI surface avoids confusion).
+7. Add a `capabilities` line to `usage`:
+
+```haskell
+  , "  plustan capabilities            Print JSON schema/feature handshake"
+```
+
+- [ ] **Step 2: Build and verify by running**
+
+```bash
+cabal build exe:plustan
+cabal run -v0 plustan -- capabilities
+```
+Expected output (exact, single line — microaeson sorts keys alphabetically; `System.Info.compilerVersion` carries only major.minor):
+`{"features":["list-onchain","analyze","fingerprints","inspection-docs"],"ghcVersion":"9.6","schemaVersion":2}`
+
+```bash
+cabal run -v0 plustan -- analyze --json 2>/dev/null | python3 -c "import json,sys; p=json.load(sys.stdin); print(p['version'], len(p['observations']), p['observations'][0]['fingerprint'] if p['observations'] else 'none')"
+```
+Expected: `2 <N> FPR-PLU-STAN-…` — version 2, top-level observations, fingerprints present (the repo's own `target/` modules are the analyzed project).
+
+- [ ] **Step 3: Bump version + changelog**
+
+`stan.cabal:3`: `version: 0.2.5.0`. Add a `CHANGELOG.md` entry at the top following the existing format: schema v2 (`fingerprint` per observation, inspection docs fields, top-level `observations`, `analysis` removed from `--json`), new `capabilities` subcommand.
+
+- [ ] **Step 4: Full backend test run**
+
+Run: `cabal test --test-show-details=direct 2>&1 | tail -10`
+Expected: suite PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/PluStan.hs stan.cabal CHANGELOG.md
+git commit -m "feat(cli): capabilities handshake and schema-v2 analyze payload (v0.2.5.0)"
+```
+
+---
+
+### Task 5: Extension unit-test infrastructure
+
+**Files:**
+- Modify: `vscode-plustan/package.json`
+- Create: `vscode-plustan/src/core/sanity.test.ts`
+
+- [ ] **Step 1: Add mocha**
+
+```bash
+cd vscode-plustan && npm install --save-dev mocha@^10.4.0 @types/mocha@^10.0.6
+```
+
+In `package.json` scripts, add:
+
+```json
+"test:unit": "npm run compile && mocha \"out/core/**/*.test.js\" \"out/analyzer/**/*.test.js\""
+```
+
+- [ ] **Step 2: Write a sanity test**
+
+`vscode-plustan/src/core/sanity.test.ts`:
+
+```ts
+import * as assert from "node:assert";
+
+describe("test infrastructure", () => {
+  it("runs", () => {
+    assert.strictEqual(1 + 1, 2);
+  });
+});
+```
+
+- [ ] **Step 3: Run**
+
+Run: `cd vscode-plustan && npm run test:unit`
+Expected: `1 passing`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vscode-plustan/package.json vscode-plustan/package-lock.json vscode-plustan/src/core/sanity.test.ts
+git commit -m "chore(ext): mocha unit-test infrastructure for vscode-free core modules"
+```
+
+---
+
+### Task 6: `core/schema.ts` — v2 payload types + validation
+
+**Files:**
+- Create: `vscode-plustan/src/core/schema.ts`
+- Test: `vscode-plustan/src/core/schema.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import * as assert from "node:assert";
+import { parseAnalyzePayload, parseCapabilities, SchemaError } from "./schema";
+
+const validPayload = {
+  version: 2,
+  runScope: "all",
+  targetModule: null,
+  inspections: [{
+    id: "PLU-STAN-04", name: "Credential eq", description: "d", solution: ["s"],
+    category: ["Plutus"], severity: "Warning",
+    whyItMatters: "w", badExample: "b", goodExample: "g", docsAnchor: "equality"
+  }],
+  observations: [{
+    id: "o1", inspectionId: "PLU-STAN-04", fingerprint: "FPR-PLU-STAN-04-abc-def",
+    file: "src/V.hs", moduleName: "V", startLine: 4, startCol: 1, endLine: 4, endCol: 10
+  }]
+};
+
+describe("schema", () => {
+  it("parses a valid v2 analyze payload", () => {
+    const p = parseAnalyzePayload(validPayload);
+    assert.strictEqual(p.observations[0].fingerprint, "FPR-PLU-STAN-04-abc-def");
+    assert.strictEqual(p.inspections[0].whyItMatters, "w");
+  });
+  it("rejects v1 payloads as unsupported-version", () => {
+    assert.throws(
+      () => parseAnalyzePayload({ version: 1, inspections: [], analysis: { observations: [] } }),
+      (e: unknown) => e instanceof SchemaError && e.reason === "unsupported-version"
+    );
+  });
+  it("rejects structurally broken payloads as malformed", () => {
+    assert.throws(
+      () => parseAnalyzePayload({ version: 2, runScope: "all", targetModule: null, inspections: [] }),
+      (e: unknown) => e instanceof SchemaError && e.reason === "malformed"
+    );
+  });
+  it("parses capabilities and rejects wrong schemaVersion", () => {
+    const c = parseCapabilities({ schemaVersion: 2, ghcVersion: "9.6", features: ["fingerprints"] });
+    assert.strictEqual(c.schemaVersion, 2);
+    assert.throws(
+      () => parseCapabilities({ schemaVersion: 3, features: [] }),
+      (e: unknown) => e instanceof SchemaError && e.reason === "unsupported-version"
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `npm run test:unit` → compile error (module missing).
+
+- [ ] **Step 3: Implement `core/schema.ts`** (no vscode imports):
+
+```ts
+export const SUPPORTED_SCHEMA_VERSION = 2;
+
+export interface InspectionV2 {
+  id: string; name: string; description: string;
+  solution: string[]; category: string[]; severity: string;
+  whyItMatters?: string; badExample?: string; goodExample?: string; docsAnchor?: string;
+}
+
+export interface ObservationV2 {
+  id: string; inspectionId: string; fingerprint: string;
+  file: string; moduleName: string;
+  startLine: number; startCol: number; endLine: number; endCol: number;
+}
+
+export interface AnalyzePayloadV2 {
+  version: number;
+  runScope: "all" | "module";
+  targetModule: string | null;
+  inspections: InspectionV2[];
+  observations: ObservationV2[];
+}
+
+export interface CapabilitiesPayload {
+  schemaVersion: number;
+  ghcVersion?: string;
+  features: string[];
+}
+
+export interface OnchainModule { moduleName: string; file: string; annotationSource: string; }
+export interface ListOnchainPayload { version: number; workspaceRoot: string; hieDir: string; modules: OnchainModule[]; }
+
+export class SchemaError extends Error {
+  constructor(readonly reason: "unsupported-version" | "malformed", message: string) {
+    super(message);
+    this.name = "SchemaError";
+  }
+}
+
+function asRecord(raw: unknown, what: string): Record<string, unknown> {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new SchemaError("malformed", `${what} is not an object`);
+  }
+  return raw as Record<string, unknown>;
+}
+
+function requireVersion(actual: unknown, what: string): void {
+  if (actual !== SUPPORTED_SCHEMA_VERSION) {
+    throw new SchemaError(
+      "unsupported-version",
+      `${what} has schema version ${String(actual)}; this extension requires ${SUPPORTED_SCHEMA_VERSION}. ` +
+      `Run "Plu-Stan: Check for Updates" to fetch a matching binary.`
+    );
+  }
+}
+
+export function parseAnalyzePayload(raw: unknown): AnalyzePayloadV2 {
+  const o = asRecord(raw, "analyze payload");
+  requireVersion(o.version, "analyze payload");
+  if (!Array.isArray(o.inspections) || !Array.isArray(o.observations)) {
+    throw new SchemaError("malformed", "analyze payload: missing inspections/observations arrays");
+  }
+  for (const obs of o.observations) {
+    const r = asRecord(obs, "observation");
+    for (const key of ["fingerprint", "inspectionId", "file", "moduleName"]) {
+      if (typeof r[key] !== "string") {
+        throw new SchemaError("malformed", `observation: missing string field '${key}'`);
+      }
+    }
+    for (const key of ["startLine", "startCol", "endLine", "endCol"]) {
+      if (typeof r[key] !== "number") {
+        throw new SchemaError("malformed", `observation: missing numeric field '${key}'`);
+      }
+    }
+  }
+  return o as unknown as AnalyzePayloadV2;
+}
+
+export function parseCapabilities(raw: unknown): CapabilitiesPayload {
+  const o = asRecord(raw, "capabilities payload");
+  requireVersion(o.schemaVersion, "plustan binary");
+  if (!Array.isArray(o.features)) {
+    throw new SchemaError("malformed", "capabilities payload: missing features array");
+  }
+  return o as unknown as CapabilitiesPayload;
+}
+
+export function parseListOnchain(raw: unknown): ListOnchainPayload {
+  const o = asRecord(raw, "list-onchain payload");
+  if (!Array.isArray(o.modules)) {
+    throw new SchemaError("malformed", "list-onchain payload: missing modules array");
+  }
+  return o as unknown as ListOnchainPayload;
+}
+```
+
+- [ ] **Step 4: Run** — `npm run test:unit` → all schema tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode-plustan/src/core/schema.ts vscode-plustan/src/core/schema.test.ts
+git commit -m "feat(ext): schema-v2 payload types and validation"
+```
+
+---
+
+### Task 7: `analyzer/client.ts` — AnalyzerClient + SpawnAnalyzerClient
+
+**Files:**
+- Create: `vscode-plustan/src/analyzer/client.ts`
+- Create: `vscode-plustan/test-fixtures/fake-plustan.js`
+- Test: `vscode-plustan/src/analyzer/client.test.ts`
+
+This moves `spawnCommand`, `parseJsonFromOutput`, and `describePluStanFailure` out of `extension.ts` (they get deleted from there in Task 14) and makes them vscode-free: logging via an injected `(line: string) => void`, cancellation via `AbortSignal`.
+
+- [ ] **Step 1: Create the fake binary fixture** `vscode-plustan/test-fixtures/fake-plustan.js`:
+
+```js
+#!/usr/bin/env node
+// Stub plustan for tests: emits canned schema-v2 JSON per subcommand.
+const cmd = process.argv[2];
+const payloads = {
+  capabilities: { schemaVersion: 2, ghcVersion: "9.6", features: ["list-onchain", "analyze", "fingerprints", "inspection-docs"] },
+  "list-onchain": {
+    version: 2, workspaceRoot: process.cwd(), hieDir: ".hie",
+    modules: [{ moduleName: "Fixture.Validator", file: "src/Fixture/Validator.hs", annotationSource: "source" }]
+  },
+  analyze: {
+    version: 2, runScope: process.argv.includes("--module") ? "module" : "all",
+    targetModule: null,
+    inspections: [{
+      id: "PLU-STAN-04", name: "Credential equality", description: "desc", solution: ["sol"],
+      category: ["Plutus"], severity: "Warning",
+      whyItMatters: "staking theft", badExample: "bad", goodExample: "good", docsAnchor: "equality"
+    }],
+    observations: [
+      { id: "o1", inspectionId: "PLU-STAN-04", fingerprint: "FPR-PLU-STAN-04-aaa-bbb",
+        file: "src/Fixture/Validator.hs", moduleName: "Fixture.Validator",
+        startLine: 3, startCol: 1, endLine: 3, endCol: 10 },
+      { id: "o2", inspectionId: "PLU-STAN-04", fingerprint: "FPR-PLU-STAN-04-aaa-ccc",
+        file: "src/Fixture/Validator.hs", moduleName: "Fixture.Validator",
+        startLine: 7, startCol: 1, endLine: 7, endCol: 10 }
+    ]
+  }
+};
+const p = payloads[cmd];
+if (!p) { process.stderr.write(`unknown command ${cmd}\n`); process.exit(1); }
+process.stdout.write(JSON.stringify(p) + "\n");
+```
+
+- [ ] **Step 2: Write the failing tests** `src/analyzer/client.test.ts`:
+
+```ts
+import * as assert from "node:assert";
+import * as path from "node:path";
+import { AnalyzerError, SpawnAnalyzerClient } from "./client";
+
+// out/analyzer/client.test.js → repo fixture dir
+const fixtures = path.resolve(__dirname, "..", "..", "test-fixtures");
+const fakeBinary = process.execPath; // node itself
+const fakeScript = path.join(fixtures, "fake-plustan.js");
+
+function client(extraArgs: string[] = []): SpawnAnalyzerClient {
+  return new SpawnAnalyzerClient(
+    () => ({
+      binaryPath: fakeBinary,
+      binaryPrefixArgs: [fakeScript], // test seam: lets node run the stub script
+      cwd: fixtures,
+      hieDir: ".hie",
+      extraArgs
+    }),
+    () => { /* silent log */ }
+  );
+}
+
+describe("SpawnAnalyzerClient", () => {
+  it("fetches and validates capabilities", async () => {
+    const caps = await client().capabilities();
+    assert.strictEqual(caps.schemaVersion, 2);
+  });
+  it("analyzes and returns a validated v2 payload", async () => {
+    const p = await client().analyze({ kind: "workspace" });
+    assert.strictEqual(p.observations.length, 2);
+    assert.strictEqual(p.observations[0].fingerprint, "FPR-PLU-STAN-04-aaa-bbb");
+  });
+  it("classifies a missing binary as not-found", async () => {
+    const bad = new SpawnAnalyzerClient(
+      () => ({ binaryPath: "/nonexistent/plustan", binaryPrefixArgs: [], cwd: fixtures, hieDir: ".hie", extraArgs: [] }),
+      () => { /* silent */ }
+    );
+    await assert.rejects(bad.capabilities(), (e: unknown) => e instanceof AnalyzerError && e.kind === "not-found");
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify failure** — `npm run test:unit` → module missing.
+
+- [ ] **Step 4: Implement `src/analyzer/client.ts`** (no vscode imports):
+
+```ts
+import { spawn } from "node:child_process";
+import {
+  AnalyzePayloadV2, CapabilitiesPayload, ListOnchainPayload,
+  parseAnalyzePayload, parseCapabilities, parseListOnchain, SchemaError
+} from "../core/schema";
+
+export type AnalyzeScope = { kind: "workspace" } | { kind: "module"; moduleName: string };
+
+export type AnalyzerErrorKind =
+  | "not-found"        // binary missing (ENOENT)
+  | "schema"           // JSON parsed but wrong schema version / shape
+  | "ghc-mismatch"     // .hie files built by a different GHC
+  | "build-failed"     // cabal build inside plustan failed
+  | "crash"            // GHC panic
+  | "no-json";         // anything else that produced no usable JSON
+
+export class AnalyzerError extends Error {
+  constructor(readonly kind: AnalyzerErrorKind, message: string) {
+    super(message);
+    this.name = "AnalyzerError";
+  }
+}
+
+export interface SpawnConfig {
+  binaryPath: string;
+  /** Args inserted before the subcommand — empty in production, used by tests to run `node fake-plustan.js …`. */
+  binaryPrefixArgs: string[];
+  cwd: string;
+  hieDir: string;
+  extraArgs: string[];
+}
+
+export interface AnalyzerClient {
+  capabilities(signal?: AbortSignal): Promise<CapabilitiesPayload>;
+  listOnchain(signal?: AbortSignal): Promise<ListOnchainPayload>;
+  analyze(scope: AnalyzeScope, signal?: AbortSignal): Promise<AnalyzePayloadV2>;
+}
+
+export class SpawnAnalyzerClient implements AnalyzerClient {
+  constructor(
+    private readonly getConfig: () => SpawnConfig,
+    private readonly log: (line: string) => void
+  ) {}
+
+  async capabilities(signal?: AbortSignal): Promise<CapabilitiesPayload> {
+    return parseCapabilities(await this.runJson(["capabilities"], signal));
+  }
+
+  async listOnchain(signal?: AbortSignal): Promise<ListOnchainPayload> {
+    const config = this.getConfig();
+    return parseListOnchain(await this.runJson(["list-onchain", "--json", "--hiedir", config.hieDir], signal));
+  }
+
+  async analyze(scope: AnalyzeScope, signal?: AbortSignal): Promise<AnalyzePayloadV2> {
+    const config = this.getConfig();
+    const args = ["analyze", "--json", "--hiedir", config.hieDir, ...config.extraArgs];
+    if (scope.kind === "module") {
+      args.push("--module", scope.moduleName);
+    }
+    return parseAnalyzePayload(await this.runJson(args, signal));
+  }
+
+  private async runJson(args: string[], signal?: AbortSignal): Promise<unknown> {
+    const config = this.getConfig();
+    const fullArgs = [...config.binaryPrefixArgs, ...args];
+    this.log(`$ ${config.binaryPath} ${fullArgs.join(" ")}`);
+
+    const { stdout, stderr, exitCode } = await this.spawnOnce(config, fullArgs, signal);
+
+    let parsed: unknown;
+    try {
+      parsed = parseJsonFromOutput(stdout);
+    } catch {
+      throw classifyNoJsonFailure(stdout, stderr, exitCode);
+    }
+    if (exitCode !== 0) {
+      this.log(`plustan exited with code ${exitCode}; using emitted JSON payload.`);
+    }
+    return parsed;
+  }
+
+  private spawnOnce(
+    config: SpawnConfig,
+    args: string[],
+    signal?: AbortSignal
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(config.binaryPath, args, { cwd: config.cwd, env: process.env });
+      let stdout = "";
+      let stderr = "";
+      const onAbort = (): void => {
+        child.kill("SIGTERM");
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+
+      child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf8"); });
+      child.stderr.on("data", (chunk: Buffer) => {
+        const text = chunk.toString("utf8");
+        stderr += text;
+        this.log(text.trimEnd());
+      });
+      child.on("error", (error: NodeJS.ErrnoException) => {
+        signal?.removeEventListener("abort", onAbort);
+        if (error.code === "ENOENT") {
+          reject(new AnalyzerError("not-found",
+            `Plu-Stan binary not found: ${config.binaryPath}. Set \`plustan.binaryPath\` or run "Plu-Stan: Check for Updates".`));
+        } else {
+          reject(new AnalyzerError("no-json", `Failed to start plustan: ${error.message}`));
+        }
+      });
+      child.on("close", (code) => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve({ stdout, stderr, exitCode: code ?? 1 });
+      });
+    });
+  }
+}
+
+/** Scan stdout lines from the end for the JSON payload (build noise may precede it). */
+export function parseJsonFromOutput(stdout: string): unknown {
+  const lines = stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    try {
+      return JSON.parse(lines[i]);
+    } catch {
+      // keep scanning earlier lines
+    }
+  }
+  return JSON.parse(stdout);
+}
+
+/** Turn a no-JSON plustan run into a typed, user-actionable error. */
+export function classifyNoJsonFailure(stdout: string, stderr: string, exitCode: number): AnalyzerError {
+  const haystack = `${stderr}\n${stdout}`;
+  if (/hie file versions|readHieFile|built by a different ghc|different ghc/i.test(haystack)) {
+    return new AnalyzerError("ghc-mismatch",
+      "Plu-Stan couldn't read your project's .hie files: they were built with a different GHC than the plustan binary. " +
+      "Rebuild with the matching GHC, or run \"Plu-Stan: Check for Updates\".");
+  }
+  if (/panic!|the 'impossible' happened/i.test(haystack)) {
+    return new AnalyzerError("crash", `Plu-Stan crashed (exit ${exitCode}). See the Plu-Stan output channel.`);
+  }
+  if (exitCode !== 0 && /error:|\[error\]/i.test(stderr)) {
+    return new AnalyzerError("build-failed",
+      "The project build failed, so analysis could not run. Fix the compile errors and save again.");
+  }
+  return new AnalyzerError("no-json",
+    `Plu-Stan produced no JSON output (exit ${exitCode}). The binary may be outdated — try "Plu-Stan: Check for Updates".`);
+}
+```
+
+Note: `SchemaError` thrown by the `parse*` functions passes through untranslated — callers distinguish `SchemaError` (update the binary) from `AnalyzerError` (run/environment problems).
+
+- [ ] **Step 5: Run** — `npm run test:unit` → all client tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vscode-plustan/src/analyzer vscode-plustan/test-fixtures/fake-plustan.js
+git commit -m "feat(ext): AnalyzerClient seam with typed failure classification"
+```
+
+---
+
+### Task 8: `core/sessionState.ts` — the session reducer
+
+**Files:**
+- Create: `vscode-plustan/src/core/sessionState.ts`
+- Test: `vscode-plustan/src/core/sessionState.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import * as assert from "node:assert";
+import { countByStatus, initialSessionState, reduceSession, SessionState } from "./sessionState";
+import { ObservationV2 } from "./schema";
+
+const obs = (fingerprint: string, file = "src/V.hs", line = 3): ObservationV2 => ({
+  id: "o", inspectionId: "PLU-STAN-04", fingerprint,
+  file, moduleName: "V", startLine: line, startCol: 1, endLine: line, endCol: 10
+});
+
+const started = (): SessionState =>
+  reduceSession(initialSessionState, { type: "sessionStarted", startedAt: "2026-07-06T10:00:00Z" });
+
+const afterRun = (state: SessionState, observations: ObservationV2[], dismissed: string[] = []): SessionState =>
+  reduceSession(state, { type: "runCompleted", coveredFiles: ["src/V.hs"], observations, dismissedFingerprints: dismissed });
+
+describe("session reducer", () => {
+  it("marks findings from a run as open", () => {
+    const s = afterRun(started(), [obs("f1"), obs("f2", "src/V.hs", 7)]);
+    assert.strictEqual(countByStatus(s).open, 2);
+  });
+  it("marks a finding fixed when a later run over its file no longer reports it", () => {
+    const s1 = afterRun(started(), [obs("f1"), obs("f2", "src/V.hs", 7)]);
+    const s2 = afterRun(s1, [obs("f2", "src/V.hs", 7)]);
+    assert.strictEqual(s2.findings["f1"].status, "fixed");
+    assert.strictEqual(s2.findings["f2"].status, "open");
+  });
+  it("does not touch findings in files not covered by the run", () => {
+    const s1 = afterRun(started(), [obs("f1"), obs("g1", "src/Other.hs")]);
+    const s2 = afterRun(s1, []); // covers only src/V.hs
+    assert.strictEqual(s2.findings["f1"].status, "fixed");
+    assert.strictEqual(s2.findings["g1"].status, "open");
+  });
+  it("marks open findings stale when their file is edited, and re-opens on re-run", () => {
+    const s1 = afterRun(started(), [obs("f1")]);
+    const s2 = reduceSession(s1, { type: "fileEdited", file: "src/V.hs" });
+    assert.strictEqual(s2.findings["f1"].status, "stale");
+    const s3 = afterRun(s2, [obs("f1")]);
+    assert.strictEqual(s3.findings["f1"].status, "open");
+  });
+  it("applies and persists dismissals across runs", () => {
+    const s1 = afterRun(started(), [obs("f1")], ["f1"]);
+    assert.strictEqual(s1.findings["f1"].status, "dismissed");
+    const s2 = afterRun(s1, [obs("f1")], ["f1"]);
+    assert.strictEqual(s2.findings["f1"].status, "dismissed");
+  });
+  it("dismisses and undismisses interactively", () => {
+    const s1 = afterRun(started(), [obs("f1")]);
+    const s2 = reduceSession(s1, { type: "findingDismissed", fingerprint: "f1" });
+    assert.strictEqual(s2.findings["f1"].status, "dismissed");
+    const s3 = reduceSession(s2, { type: "findingUndismissed", fingerprint: "f1" });
+    assert.strictEqual(s3.findings["f1"].status, "open");
+  });
+  it("ends the session back to idle but keeps findings for the summary", () => {
+    const s = reduceSession(afterRun(started(), [obs("f1")]), { type: "sessionEnded" });
+    assert.strictEqual(s.phase, "idle");
+    assert.strictEqual(Object.keys(s.findings).length, 1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `npm run test:unit`.
+
+- [ ] **Step 3: Implement `core/sessionState.ts`** (no vscode imports):
+
+```ts
+import { ObservationV2 } from "./schema";
+
+export type FindingStatus = "open" | "stale" | "fixed" | "dismissed";
+
+export interface SessionFinding extends ObservationV2 {
+  status: FindingStatus;
+  lastSeenRun: number;
+}
+
+export interface SessionState {
+  phase: "idle" | "active";
+  startedAt: string | null;
+  runCount: number;
+  findings: Record<string, SessionFinding>;
+}
+
+export type SessionEvent =
+  | { type: "sessionStarted"; startedAt: string }
+  | { type: "runCompleted"; coveredFiles: string[]; observations: ObservationV2[]; dismissedFingerprints: string[] }
+  | { type: "fileEdited"; file: string }
+  | { type: "findingDismissed"; fingerprint: string }
+  | { type: "findingUndismissed"; fingerprint: string }
+  | { type: "sessionEnded" };
+
+export const initialSessionState: SessionState = {
+  phase: "idle",
+  startedAt: null,
+  runCount: 0,
+  findings: {}
+};
+
+export function reduceSession(state: SessionState, event: SessionEvent): SessionState {
+  switch (event.type) {
+    case "sessionStarted":
+      return { phase: "active", startedAt: event.startedAt, runCount: 0, findings: {} };
+
+    case "sessionEnded":
+      return { ...state, phase: "idle" };
+
+    case "runCompleted": {
+      const covered = new Set(event.coveredFiles);
+      const dismissed = new Set(event.dismissedFingerprints);
+      const runCount = state.runCount + 1;
+      const findings: Record<string, SessionFinding> = {};
+
+      // Carry forward everything in files this run did not cover.
+      for (const f of Object.values(state.findings)) {
+        if (!covered.has(f.file)) {
+          findings[f.fingerprint] = f;
+        }
+      }
+      // Everything reported by this run is open (or dismissed).
+      for (const o of event.observations) {
+        findings[o.fingerprint] = {
+          ...o,
+          status: dismissed.has(o.fingerprint) ? "dismissed" : "open",
+          lastSeenRun: runCount
+        };
+      }
+      // Previously-known findings in covered files that were NOT re-reported: fixed.
+      for (const f of Object.values(state.findings)) {
+        if (covered.has(f.file) && findings[f.fingerprint] === undefined) {
+          findings[f.fingerprint] =
+            f.status === "open" || f.status === "stale" ? { ...f, status: "fixed" } : f;
+        }
+      }
+      return { ...state, runCount, findings };
+    }
+
+    case "fileEdited": {
+      const findings = { ...state.findings };
+      for (const f of Object.values(findings)) {
+        if (f.file === event.file && f.status === "open") {
+          findings[f.fingerprint] = { ...f, status: "stale" };
+        }
+      }
+      return { ...state, findings };
+    }
+
+    case "findingDismissed":
+    case "findingUndismissed": {
+      const f = state.findings[event.fingerprint];
+      if (!f) {
+        return state;
+      }
+      const status: FindingStatus = event.type === "findingDismissed" ? "dismissed" : "open";
+      return { ...state, findings: { ...state.findings, [event.fingerprint]: { ...f, status } } };
+    }
+  }
+}
+
+export function countByStatus(state: SessionState): Record<FindingStatus, number> {
+  const counts: Record<FindingStatus, number> = { open: 0, stale: 0, fixed: 0, dismissed: 0 };
+  for (const f of Object.values(state.findings)) {
+    counts[f.status] += 1;
+  }
+  return counts;
+}
+```
+
+- [ ] **Step 4: Run** — `npm run test:unit` → all reducer tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode-plustan/src/core/sessionState.ts vscode-plustan/src/core/sessionState.test.ts
+git commit -m "feat(ext): pure review-session reducer (open/stale/fixed/dismissed)"
+```
+
+---
+
+### Task 9: Dismissals — pure logic + workspace store
+
+**Files:**
+- Create: `vscode-plustan/src/core/dismissals.ts`, `vscode-plustan/src/session/dismissalsStore.ts`
+- Test: `vscode-plustan/src/core/dismissals.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import * as assert from "node:assert";
+import { addDismissal, emptyDismissals, parseDismissals, removeDismissal, serializeDismissals } from "./dismissals";
+
+describe("dismissals", () => {
+  it("round-trips through serialize/parse", () => {
+    const d1 = addDismissal(emptyDismissals(), {
+      fingerprint: "f1", inspectionId: "PLU-STAN-04", note: "intentional", dismissedAt: "2026-07-06T10:00:00Z"
+    });
+    const d2 = parseDismissals(serializeDismissals(d1));
+    assert.deepStrictEqual(d2, d1);
+  });
+  it("dedupes by fingerprint", () => {
+    const base = addDismissal(emptyDismissals(), { fingerprint: "f1", inspectionId: "X", dismissedAt: "t" });
+    const twice = addDismissal(base, { fingerprint: "f1", inspectionId: "X", dismissedAt: "t2" });
+    assert.strictEqual(twice.dismissals.length, 1);
+    assert.strictEqual(twice.dismissals[0].dismissedAt, "t2");
+  });
+  it("removes by fingerprint", () => {
+    const base = addDismissal(emptyDismissals(), { fingerprint: "f1", inspectionId: "X", dismissedAt: "t" });
+    assert.strictEqual(removeDismissal(base, "f1").dismissals.length, 0);
+  });
+  it("tolerates broken file content", () => {
+    assert.deepStrictEqual(parseDismissals("not json {"), emptyDismissals());
+    assert.deepStrictEqual(parseDismissals('{"version":1}'), emptyDismissals());
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement `core/dismissals.ts`** (no vscode imports):
+
+```ts
+export interface DismissalEntry {
+  fingerprint: string;
+  inspectionId: string;
+  note?: string;
+  dismissedAt: string;
+}
+
+export interface DismissalsFile {
+  version: 1;
+  dismissals: DismissalEntry[];
+}
+
+export function emptyDismissals(): DismissalsFile {
+  return { version: 1, dismissals: [] };
+}
+
+export function parseDismissals(text: string): DismissalsFile {
+  try {
+    const raw = JSON.parse(text) as { version?: unknown; dismissals?: unknown };
+    if (!Array.isArray(raw.dismissals)) {
+      return emptyDismissals();
+    }
+    const dismissals = raw.dismissals.filter(
+      (d): d is DismissalEntry =>
+        typeof d === "object" && d !== null &&
+        typeof (d as DismissalEntry).fingerprint === "string" &&
+        typeof (d as DismissalEntry).inspectionId === "string"
+    );
+    return { version: 1, dismissals };
+  } catch {
+    return emptyDismissals();
+  }
+}
+
+export function serializeDismissals(file: DismissalsFile): string {
+  return JSON.stringify(file, null, 2) + "\n";
+}
+
+export function addDismissal(file: DismissalsFile, entry: DismissalEntry): DismissalsFile {
+  return {
+    version: 1,
+    dismissals: [...file.dismissals.filter((d) => d.fingerprint !== entry.fingerprint), entry]
+  };
+}
+
+export function removeDismissal(file: DismissalsFile, fingerprint: string): DismissalsFile {
+  return { version: 1, dismissals: file.dismissals.filter((d) => d.fingerprint !== fingerprint) };
+}
+```
+
+- [ ] **Step 4: Implement `session/dismissalsStore.ts`** (vscode-coupled, thin):
+
+```ts
+import * as vscode from "vscode";
+import { DismissalEntry, DismissalsFile, addDismissal, emptyDismissals, parseDismissals, removeDismissal, serializeDismissals } from "../core/dismissals";
+
+const FILE_PATH = ".plustan/dismissals.json";
+
+export class DismissalsStore {
+  constructor(private readonly folder: vscode.WorkspaceFolder) {}
+
+  private get uri(): vscode.Uri {
+    return vscode.Uri.joinPath(this.folder.uri, FILE_PATH);
+  }
+
+  async load(): Promise<DismissalsFile> {
+    try {
+      const bytes = await vscode.workspace.fs.readFile(this.uri);
+      return parseDismissals(Buffer.from(bytes).toString("utf8"));
+    } catch {
+      return emptyDismissals(); // file absent
+    }
+  }
+
+  async add(entry: DismissalEntry): Promise<DismissalsFile> {
+    const next = addDismissal(await this.load(), entry);
+    await this.save(next);
+    return next;
+  }
+
+  async remove(fingerprint: string): Promise<DismissalsFile> {
+    const next = removeDismissal(await this.load(), fingerprint);
+    await this.save(next);
+    return next;
+  }
+
+  private async save(file: DismissalsFile): Promise<void> {
+    await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(this.folder.uri, ".plustan"));
+    await vscode.workspace.fs.writeFile(this.uri, Buffer.from(serializeDismissals(file), "utf8"));
+  }
+}
+```
+
+- [ ] **Step 5: Run** — `npm run test:unit` → dismissal tests PASS; `npm run compile` clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vscode-plustan/src/core/dismissals.ts vscode-plustan/src/core/dismissals.test.ts vscode-plustan/src/session/dismissalsStore.ts
+git commit -m "feat(ext): persistent dismissals in .plustan/dismissals.json"
+```
+
+---
+
+### Task 10: `core/runCoalescer.ts` — pending-run queue
+
+**Files:**
+- Create: `vscode-plustan/src/core/runCoalescer.ts`
+- Test: `vscode-plustan/src/core/runCoalescer.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import * as assert from "node:assert";
+import { RunCoalescer } from "./runCoalescer";
+
+describe("RunCoalescer", () => {
+  it("coalesces duplicate module requests", () => {
+    const q = new RunCoalescer();
+    q.request({ kind: "module", moduleName: "A" });
+    q.request({ kind: "module", moduleName: "A" });
+    q.request({ kind: "module", moduleName: "B" });
+    assert.strictEqual(q.size, 2);
+  });
+  it("a workspace request subsumes all pending module requests", () => {
+    const q = new RunCoalescer();
+    q.request({ kind: "module", moduleName: "A" });
+    q.request({ kind: "workspace" });
+    assert.strictEqual(q.size, 1);
+    assert.deepStrictEqual(q.takeNext(), { kind: "workspace" });
+  });
+  it("module requests while a workspace run is pending are absorbed", () => {
+    const q = new RunCoalescer();
+    q.request({ kind: "workspace" });
+    q.request({ kind: "module", moduleName: "A" });
+    assert.strictEqual(q.size, 1);
+  });
+  it("serves FIFO otherwise", () => {
+    const q = new RunCoalescer();
+    q.request({ kind: "module", moduleName: "A" });
+    q.request({ kind: "module", moduleName: "B" });
+    assert.deepStrictEqual(q.takeNext(), { kind: "module", moduleName: "A" });
+    assert.deepStrictEqual(q.takeNext(), { kind: "module", moduleName: "B" });
+    assert.strictEqual(q.takeNext(), undefined);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement `core/runCoalescer.ts`:**
+
+```ts
+export type PendingRun = { kind: "workspace" } | { kind: "module"; moduleName: string };
+
+/** Pending analysis runs: duplicates coalesce, workspace subsumes modules. */
+export class RunCoalescer {
+  private pending: PendingRun[] = [];
+
+  request(run: PendingRun): void {
+    if (this.pending.some((p) => p.kind === "workspace")) {
+      return; // a pending workspace run already covers everything
+    }
+    if (run.kind === "workspace") {
+      this.pending = [{ kind: "workspace" }];
+      return;
+    }
+    if (!this.pending.some((p) => p.kind === "module" && p.moduleName === run.moduleName)) {
+      this.pending.push(run);
+    }
+  }
+
+  takeNext(): PendingRun | undefined {
+    return this.pending.shift();
+  }
+
+  get size(): number {
+    return this.pending.length;
+  }
+}
+```
+
+- [ ] **Step 4: Run** — `npm run test:unit` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode-plustan/src/core/runCoalescer.ts vscode-plustan/src/core/runCoalescer.test.ts
+git commit -m "feat(ext): run coalescing for save-triggered analyses"
+```
+
+---
+
+### Task 11: Status bar + review controller
+
+**Files:**
+- Create: `vscode-plustan/src/ui/statusBar.ts`, `vscode-plustan/src/session/controller.ts`
+
+These are vscode-coupled; their pure logic already lives in Tasks 8/10. Verification is `npm run compile` here plus the integration test in Task 15.
+
+- [ ] **Step 1: Implement `ui/statusBar.ts`:**
+
+```ts
+import * as vscode from "vscode";
+import { countByStatus, SessionState } from "../core/sessionState";
+
+export class PluStanStatusBar implements vscode.Disposable {
+  private readonly item: vscode.StatusBarItem;
+
+  constructor() {
+    this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 50);
+    this.item.command = "plustanFindings.focus";
+  }
+
+  update(state: SessionState, running: boolean, buildFailed: boolean): void {
+    if (state.phase === "idle") {
+      this.item.hide();
+      return;
+    }
+    const counts = countByStatus(state);
+    const spinner = running ? "$(sync~spin) " : "";
+    const failure = buildFailed ? " · build failed — results stale" : "";
+    this.item.text = `${spinner}Plu-Stan: ${counts.open + counts.stale} open · ${counts.fixed} fixed${failure}`;
+    this.item.tooltip = "Plu-Stan review session — click to open findings";
+    this.item.show();
+  }
+
+  dispose(): void {
+    this.item.dispose();
+  }
+}
+```
+
+- [ ] **Step 2: Implement `session/controller.ts`:**
+
+```ts
+import * as vscode from "vscode";
+import { AnalyzerClient, AnalyzerError, AnalyzeScope } from "../analyzer/client";
+import { InspectionV2, SchemaError } from "../core/schema";
+import { initialSessionState, reduceSession, SessionState } from "../core/sessionState";
+import { PendingRun, RunCoalescer } from "../core/runCoalescer";
+import { DismissalsStore } from "./dismissalsStore";
+import { PluStanStatusBar } from "../ui/statusBar";
+
+const SESSION_STORAGE_KEY = "plustan.session.v1";
+const SAVE_DEBOUNCE_MS = 500;
+
+interface PersistedSession {
+  state: SessionState;
+  inspections: [string, InspectionV2][];
+  moduleByFile: [string, string][];
+}
+
+export class ReviewController implements vscode.Disposable {
+  private state: SessionState = initialSessionState;
+  private inspections = new Map<string, InspectionV2>();
+  private moduleByFile = new Map<string, string>(); // absolute-ish file path → module name
+  private readonly queue = new RunCoalescer();
+  private running = false;
+  private buildFailed = false;
+  private debounceTimer: NodeJS.Timeout | undefined;
+  private abort: AbortController | undefined;
+  private readonly disposables: vscode.Disposable[] = [];
+
+  constructor(
+    private readonly client: AnalyzerClient,
+    private readonly dismissals: DismissalsStore,
+    private readonly statusBar: PluStanStatusBar,
+    private readonly workspaceState: vscode.Memento,
+    private readonly onStateChange: (state: SessionState, inspections: Map<string, InspectionV2>) => void,
+    private readonly output: vscode.OutputChannel
+  ) {
+    this.disposables.push(
+      vscode.workspace.onDidSaveTextDocument((doc) => this.handleSave(doc)),
+      // Spec: a finding is stale as soon as its file is *edited*, not only
+      // once saved — unsaved buffer changes already invalidate positions.
+      vscode.workspace.onDidChangeTextDocument((e) => {
+        if (this.state.phase === "active" && e.contentChanges.length > 0) {
+          const file = this.fileKeyForDocument(e.document);
+          if (this.moduleForDocument(e.document)) {
+            this.dispatch({ type: "fileEdited", file });
+          }
+        }
+      })
+    );
+  }
+
+  get sessionState(): SessionState { return this.state; }
+  get inspectionDocs(): Map<string, InspectionV2> { return this.inspections; }
+
+  restore(): void {
+    const saved = this.workspaceState.get<PersistedSession>(SESSION_STORAGE_KEY);
+    if (saved && saved.state.phase === "active") {
+      this.state = saved.state;
+      this.inspections = new Map(saved.inspections);
+      this.moduleByFile = new Map(saved.moduleByFile);
+      void vscode.commands.executeCommand("setContext", "plustan.sessionActive", true);
+      this.publish();
+    }
+  }
+
+  /**
+   * Start a review. Scope per spec: the whole workspace or a chosen set of
+   * onchain modules. `scopeArg === "all"` (or a workspace with ≤1 module)
+   * skips the picker — used programmatically and by the integration test.
+   */
+  async startReview(scopeArg?: "all" | string[]): Promise<void> {
+    // Capabilities handshake: old binaries and future schemas fail here, up front.
+    let moduleByFile: Map<string, string>;
+    try {
+      await this.client.capabilities();
+      const list = await this.client.listOnchain();
+      moduleByFile = new Map(list.modules.map((m) => [m.file, m.moduleName]));
+    } catch (error) {
+      await this.explainStartFailure(error);
+      return;
+    }
+
+    if (scopeArg === undefined && moduleByFile.size > 1) {
+      const picks = await vscode.window.showQuickPick(
+        [...moduleByFile.values()].sort().map((moduleName) => ({ label: moduleName, picked: true })),
+        { canPickMany: true, placeHolder: "Modules to review (all preselected)" }
+      );
+      if (!picks) {
+        return; // user cancelled
+      }
+      scopeArg = picks.map((p) => p.label);
+    }
+    if (Array.isArray(scopeArg)) {
+      const wanted = new Set(scopeArg);
+      moduleByFile = new Map([...moduleByFile.entries()].filter(([, m]) => wanted.has(m)));
+    }
+    this.moduleByFile = moduleByFile;
+
+    this.dispatch({ type: "sessionStarted", startedAt: new Date().toISOString() });
+    await vscode.commands.executeCommand("setContext", "plustan.sessionActive", true);
+    this.queue.request({ kind: "workspace" });
+    void this.pump();
+  }
+
+  async endReview(): Promise<void> {
+    this.dispatch({ type: "sessionEnded" });
+    await vscode.commands.executeCommand("setContext", "plustan.sessionActive", false);
+    this.abort?.abort();
+    const c = this.state.findings;
+    this.output.appendLine(
+      `Plu-Stan review ended: ${Object.values(c).filter((f) => f.status === "fixed").length} fixed, ` +
+      `${Object.values(c).filter((f) => f.status === "open" || f.status === "stale").length} open, ` +
+      `${Object.values(c).filter((f) => f.status === "dismissed").length} dismissed.`
+    );
+  }
+
+  async dismiss(fingerprint: string, inspectionId: string, note?: string): Promise<void> {
+    await this.dismissals.add({ fingerprint, inspectionId, note, dismissedAt: new Date().toISOString() });
+    this.dispatch({ type: "findingDismissed", fingerprint });
+  }
+
+  async undismiss(fingerprint: string): Promise<void> {
+    await this.dismissals.remove(fingerprint);
+    this.dispatch({ type: "findingUndismissed", fingerprint });
+  }
+
+  private handleSave(doc: vscode.TextDocument): void {
+    if (this.state.phase !== "active") {
+      return;
+    }
+    const moduleName = this.moduleForDocument(doc);
+    if (!moduleName) {
+      return;
+    }
+    this.dispatch({ type: "fileEdited", file: this.fileKeyForDocument(doc) });
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.queue.request({ kind: "module", moduleName });
+      void this.pump();
+    }, SAVE_DEBOUNCE_MS);
+  }
+
+  /** The backend reports workspace-relative paths; match on suffix. */
+  private moduleForDocument(doc: vscode.TextDocument): string | undefined {
+    for (const [file, moduleName] of this.moduleByFile) {
+      if (doc.fileName.endsWith(file)) {
+        return moduleName;
+      }
+    }
+    return undefined;
+  }
+
+  private fileKeyForDocument(doc: vscode.TextDocument): string {
+    for (const [file] of this.moduleByFile) {
+      if (doc.fileName.endsWith(file)) {
+        return file;
+      }
+    }
+    return doc.fileName;
+  }
+
+  private async pump(): Promise<void> {
+    if (this.running) {
+      return;
+    }
+    const next = this.queue.takeNext();
+    if (!next) {
+      return;
+    }
+    this.running = true;
+    this.publish();
+    try {
+      await this.runOne(next);
+      this.buildFailed = false;
+    } catch (error) {
+      if (error instanceof AnalyzerError && error.kind === "build-failed") {
+        this.buildFailed = true; // keep findings; status bar explains; next save retries
+        this.output.appendLine(error.message);
+      } else {
+        this.output.appendLine(`Plu-Stan run failed: ${error instanceof Error ? error.message : String(error)}`);
+        void vscode.window.showErrorMessage(`Plu-Stan: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    } finally {
+      this.running = false;
+      this.publish();
+      if (this.queue.size > 0) {
+        void this.pump();
+      }
+    }
+  }
+
+  private async runOne(run: PendingRun): Promise<void> {
+    this.abort = new AbortController();
+    const scope: AnalyzeScope = run.kind === "workspace"
+      ? { kind: "workspace" }
+      : { kind: "module", moduleName: run.moduleName };
+    const payload = await this.client.analyze(scope, this.abort.signal);
+
+    for (const inspection of payload.inspections) {
+      this.inspections.set(inspection.id, inspection);
+    }
+    const coveredFiles = run.kind === "workspace"
+      ? [...this.moduleByFile.keys()]
+      : [...this.moduleByFile.entries()].filter(([, m]) => m === run.moduleName).map(([f]) => f);
+    // A module-scoped session still gets whole-project observations from a
+    // workspace-kind run — keep only files inside the session scope.
+    const covered = new Set(coveredFiles);
+    const observations = payload.observations.filter((o) => covered.has(o.file));
+    const dismissed = (await this.dismissals.load()).dismissals.map((d) => d.fingerprint);
+    this.dispatch({
+      type: "runCompleted",
+      coveredFiles,
+      observations,
+      dismissedFingerprints: dismissed
+    });
+  }
+
+  private dispatch(event: Parameters<typeof reduceSession>[1]): void {
+    this.state = reduceSession(this.state, event);
+    void this.workspaceState.update(SESSION_STORAGE_KEY, {
+      state: this.state,
+      inspections: [...this.inspections.entries()],
+      moduleByFile: [...this.moduleByFile.entries()]
+    } satisfies PersistedSession);
+    this.publish();
+  }
+
+  private publish(): void {
+    this.statusBar.update(this.state, this.running, this.buildFailed);
+    this.onStateChange(this.state, this.inspections);
+  }
+
+  private async explainStartFailure(error: unknown): Promise<void> {
+    const message = error instanceof SchemaError || error instanceof AnalyzerError
+      ? error.message
+      : `Plu-Stan handshake failed: ${error instanceof Error ? error.message : String(error)}`;
+    const choice = await vscode.window.showErrorMessage(message, "Check for Updates");
+    if (choice === "Check for Updates") {
+      await vscode.commands.executeCommand("plustan.checkForUpdates");
+    }
+  }
+
+  dispose(): void {
+    this.abort?.abort();
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    for (const d of this.disposables) {
+      d.dispose();
+    }
+  }
+}
+```
+
+Note on the old-binary handshake path: a pre-v2 binary treats `capabilities` as a legacy positional project dir, prints an error to stderr, and emits no JSON — that surfaces as `AnalyzerError("no-json", …)` whose message already suggests "Check for Updates". No extra handling needed.
+
+- [ ] **Step 3: Compile** — `cd vscode-plustan && npm run compile` → clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vscode-plustan/src/ui/statusBar.ts vscode-plustan/src/session/controller.ts
+git commit -m "feat(ext): review-session controller with save-triggered re-runs"
+```
+
+---
+
+### Task 12: Findings tree + package.json contributions
+
+**Files:**
+- Create: `vscode-plustan/src/ui/findingsTree.ts`
+- Modify: `vscode-plustan/package.json`
+
+- [ ] **Step 1: package.json contributions**
+
+In `contributes.views.plustan`, replace the single view with (order matters — findings first):
+
+```json
+"views": {
+  "plustan": [
+    { "id": "plustanFindings", "name": "Findings" },
+    { "id": "plustanFindingDetail", "name": "Finding Detail", "type": "webview" },
+    { "id": "plustanOnchainModules", "name": "Onchain Modules" }
+  ]
+}
+```
+
+Add to `contributes.commands`:
+
+```json
+{ "command": "plustan.startReview", "title": "Plu-Stan: Start Review", "icon": "$(play)" },
+{ "command": "plustan.endReview", "title": "Plu-Stan: End Review", "icon": "$(debug-stop)" },
+{ "command": "plustan.toggleFindingsGrouping", "title": "Plu-Stan: Toggle Findings Grouping", "icon": "$(list-tree)" },
+{ "command": "plustan.openFinding", "title": "Plu-Stan: Open Finding" },
+{ "command": "plustan.dismissFinding", "title": "Plu-Stan: Dismiss Finding", "icon": "$(close)" },
+{ "command": "plustan.undismissFinding", "title": "Plu-Stan: Restore Dismissed Finding", "icon": "$(redo)" }
+```
+
+Add `contributes.menus`:
+
+```json
+"menus": {
+  "view/title": [
+    { "command": "plustan.startReview", "when": "view == plustanFindings && plustan.sessionActive != true", "group": "navigation@1" },
+    { "command": "plustan.endReview", "when": "view == plustanFindings && plustan.sessionActive == true", "group": "navigation@1" },
+    { "command": "plustan.toggleFindingsGrouping", "when": "view == plustanFindings", "group": "navigation@2" }
+  ],
+  "view/item/context": [
+    { "command": "plustan.dismissFinding", "when": "view == plustanFindings && viewItem == plustanFinding", "group": "inline" },
+    { "command": "plustan.undismissFinding", "when": "view == plustanFindings && viewItem == plustanDismissedFinding", "group": "inline" }
+  ]
+}
+```
+
+- [ ] **Step 2: Implement `ui/findingsTree.ts`:**
+
+```ts
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { InspectionV2 } from "../core/schema";
+import { SessionFinding, SessionState, initialSessionState } from "../core/sessionState";
+
+type Grouping = "severity" | "module";
+
+const SEVERITY_ORDER = ["Error", "Warning", "PotentialBug", "Performance", "Style"];
+
+class GroupItem extends vscode.TreeItem {
+  constructor(label: string, readonly children: (GroupItem | FindingTreeItem)[], icon?: string) {
+    super(label, vscode.TreeItemCollapsibleState.Expanded);
+    if (icon) {
+      this.iconPath = new vscode.ThemeIcon(icon);
+    }
+  }
+}
+
+export class FindingTreeItem extends vscode.TreeItem {
+  constructor(readonly finding: SessionFinding, inspection: InspectionV2 | undefined) {
+    super(`${path.basename(finding.file)}:${finding.startLine}`, vscode.TreeItemCollapsibleState.None);
+    this.description = inspection ? inspection.name : finding.inspectionId;
+    this.tooltip = `[${finding.inspectionId}] ${finding.file}:${finding.startLine}:${finding.startCol}`;
+    this.contextValue = finding.status === "dismissed" ? "plustanDismissedFinding" : "plustanFinding";
+    this.iconPath = new vscode.ThemeIcon(
+      finding.status === "stale" ? "history"
+        : finding.status === "fixed" ? "check"
+        : finding.status === "dismissed" ? "circle-slash"
+        : "warning"
+    );
+    if (finding.status === "stale") {
+      this.description = `~ ${this.description ?? ""}`;
+    }
+    this.command = { command: "plustan.openFinding", title: "Open Finding", arguments: [this] };
+  }
+}
+
+type Node = GroupItem | FindingTreeItem;
+
+export class FindingsTreeProvider implements vscode.TreeDataProvider<Node> {
+  private state: SessionState = initialSessionState;
+  private inspections = new Map<string, InspectionV2>();
+  private grouping: Grouping = "severity";
+  private readonly emitter = new vscode.EventEmitter<Node | undefined>();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  setData(state: SessionState, inspections: Map<string, InspectionV2>): void {
+    this.state = state;
+    this.inspections = inspections;
+    this.emitter.fire(undefined);
+  }
+
+  toggleGrouping(): void {
+    this.grouping = this.grouping === "severity" ? "module" : "severity";
+    this.emitter.fire(undefined);
+  }
+
+  getTreeItem(element: Node): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: Node): Node[] {
+    if (element) {
+      return element instanceof GroupItem ? element.children : [];
+    }
+    if (this.state.phase === "idle") {
+      const idle = new vscode.TreeItem("No active review — press ▶ to start");
+      return [idle as Node];
+    }
+    return this.buildRoots();
+  }
+
+  private buildRoots(): Node[] {
+    const all = Object.values(this.state.findings);
+    const active = all.filter((f) => f.status === "open" || f.status === "stale");
+    const fixed = all.filter((f) => f.status === "fixed");
+    const dismissed = all.filter((f) => f.status === "dismissed");
+
+    const roots: Node[] = this.grouping === "severity"
+      ? this.groupBySeverity(active)
+      : this.groupByModule(active);
+
+    if (fixed.length > 0) {
+      const node = new GroupItem(`Fixed this session (${fixed.length})`, fixed.map((f) => this.item(f)), "check");
+      node.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+      roots.push(node);
+    }
+    if (dismissed.length > 0) {
+      const node = new GroupItem(`Dismissed (${dismissed.length})`, dismissed.map((f) => this.item(f)), "circle-slash");
+      node.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+      roots.push(node);
+    }
+    return roots;
+  }
+
+  private groupBySeverity(findings: SessionFinding[]): Node[] {
+    const severityOf = (f: SessionFinding): string => this.inspections.get(f.inspectionId)?.severity ?? "Warning";
+    const severities = [...new Set(findings.map(severityOf))]
+      .sort((a, b) => SEVERITY_ORDER.indexOf(a) - SEVERITY_ORDER.indexOf(b));
+    return severities.map((severity) => {
+      const inSeverity = findings.filter((f) => severityOf(f) === severity);
+      const ruleIds = [...new Set(inSeverity.map((f) => f.inspectionId))].sort();
+      const ruleNodes = ruleIds.map((ruleId) => {
+        const inRule = inSeverity.filter((f) => f.inspectionId === ruleId).sort(bySpan);
+        const name = this.inspections.get(ruleId)?.name ?? "";
+        return new GroupItem(`${ruleId} ${name} (${inRule.length})`, inRule.map((f) => this.item(f)));
+      });
+      return new GroupItem(`${severity} (${inSeverity.length})`, ruleNodes, severityIcon(severity));
+    });
+  }
+
+  private groupByModule(findings: SessionFinding[]): Node[] {
+    const modules = [...new Set(findings.map((f) => f.moduleName))].sort();
+    return modules.map((moduleName) => {
+      const inModule = findings.filter((f) => f.moduleName === moduleName).sort(bySpan);
+      return new GroupItem(`${moduleName} (${inModule.length})`, inModule.map((f) => this.item(f)), "symbol-module");
+    });
+  }
+
+  private item(f: SessionFinding): FindingTreeItem {
+    return new FindingTreeItem(f, this.inspections.get(f.inspectionId));
+  }
+}
+
+function bySpan(a: SessionFinding, b: SessionFinding): number {
+  return a.file.localeCompare(b.file) || a.startLine - b.startLine || a.startCol - b.startCol;
+}
+
+function severityIcon(severity: string): string {
+  return severity === "Error" ? "error" : severity === "Performance" ? "zap" : "warning";
+}
+```
+
+- [ ] **Step 3: Compile** — `npm run compile` → clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vscode-plustan/src/ui/findingsTree.ts vscode-plustan/package.json
+git commit -m "feat(ext): findings tree with severity/module grouping and status sections"
+```
+
+---
+
+### Task 13: Detail panel (webview view)
+
+**Files:**
+- Create: `vscode-plustan/src/ui/detailPanel.ts`
+
+- [ ] **Step 1: Implement `ui/detailPanel.ts`:**
+
+```ts
+import * as vscode from "vscode";
+import { InspectionV2 } from "../core/schema";
+import { SessionFinding } from "../core/sessionState";
+
+const RULES_URL = "https://github.com/input-output-hk/plu-stan/blob/main/RULES.md";
+
+export class FindingDetailProvider implements vscode.WebviewViewProvider {
+  static readonly viewId = "plustanFindingDetail";
+  private view: vscode.WebviewView | undefined;
+  private current: { finding: SessionFinding; inspection?: InspectionV2 } | undefined;
+
+  constructor(
+    private readonly onDismiss: (finding: SessionFinding) => void,
+    private readonly onOpen: (finding: SessionFinding) => void
+  ) {}
+
+  resolveWebviewView(view: vscode.WebviewView): void {
+    this.view = view;
+    view.webview.options = { enableScripts: true };
+    view.webview.onDidReceiveMessage((msg: { type: string }) => {
+      if (!this.current) {
+        return;
+      }
+      if (msg.type === "dismiss") {
+        this.onDismiss(this.current.finding);
+      } else if (msg.type === "open") {
+        this.onOpen(this.current.finding);
+      }
+    });
+    this.render();
+  }
+
+  showFinding(finding: SessionFinding, inspection: InspectionV2 | undefined): void {
+    this.current = { finding, inspection };
+    this.render();
+    this.view?.show?.(true);
+  }
+
+  clear(): void {
+    this.current = undefined;
+    this.render();
+  }
+
+  private render(): void {
+    if (!this.view) {
+      return;
+    }
+    this.view.webview.html = this.current
+      ? findingHtml(this.current.finding, this.current.inspection)
+      : emptyHtml();
+  }
+}
+
+function esc(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function emptyHtml(): string {
+  return wrap("<p class='muted'>Select a finding in the tree to see its explanation.</p>");
+}
+
+function findingHtml(f: SessionFinding, inspection: InspectionV2 | undefined): string {
+  const name = inspection?.name ?? f.inspectionId;
+  const severity = inspection?.severity ?? "";
+  const why = inspection?.whyItMatters ?? inspection?.description ?? "";
+  const solutions = (inspection?.solution ?? []).map((s) => `<li>${esc(s)}</li>`).join("");
+  const docsLink = inspection?.docsAnchor
+    ? `<a href="${RULES_URL}#${esc(inspection.docsAnchor)}">Rule documentation</a>`
+    : "";
+  const examples = inspection?.badExample && inspection?.goodExample
+    ? `<h3>✗ Avoid</h3><pre>${esc(inspection.badExample)}</pre>
+       <h3>✓ Prefer</h3><pre>${esc(inspection.goodExample)}</pre>`
+    : "";
+  return wrap(`
+    <h2>${esc(f.inspectionId)} · ${esc(name)}</h2>
+    <p class="muted">${esc(severity)} · ${esc(f.file)}:${f.startLine}:${f.startCol} · status: ${esc(f.status)}</p>
+    ${why ? `<p>${esc(why)}</p>` : ""}
+    ${examples}
+    ${solutions ? `<h3>How to fix</h3><ul>${solutions}</ul>` : ""}
+    <p>${docsLink}</p>
+    <div class="actions">
+      <button onclick="post('open')">Open file</button>
+      <button onclick="post('dismiss')">Dismiss</button>
+    </div>
+  `);
+}
+
+function wrap(body: string): string {
+  return `<!DOCTYPE html><html><head><meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
+    <style>
+      body { font-family: var(--vscode-font-family); font-size: 13px; padding: 8px; }
+      pre { background: var(--vscode-textCodeBlock-background); padding: 6px; overflow-x: auto; }
+      .muted { opacity: 0.7; }
+      button { margin-right: 6px; }
+    </style></head>
+    <body>${body}
+    <script>const vscode = acquireVsCodeApi(); function post(type) { vscode.postMessage({ type }); }</script>
+    </body></html>`;
+}
+```
+
+- [ ] **Step 2: Compile** — `npm run compile` → clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add vscode-plustan/src/ui/detailPanel.ts
+git commit -m "feat(ext): finding detail panel rendering backend-shipped rule docs"
+```
+
+---
+
+### Task 14: Diagnostics from session state + dismiss code action + extension wiring
+
+**Files:**
+- Create: `vscode-plustan/src/diagnostics.ts`
+- Modify: `vscode-plustan/src/extension.ts`
+
+- [ ] **Step 1: Implement `src/diagnostics.ts`:**
+
+```ts
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { InspectionV2 } from "./core/schema";
+import { SessionFinding, SessionState } from "./core/sessionState";
+
+export interface PluStanDiagnostic extends vscode.Diagnostic {
+  plustanFingerprint?: string;
+  plustanInspectionId?: string;
+}
+
+export function publishSessionDiagnostics(
+  state: SessionState,
+  inspections: Map<string, InspectionV2>,
+  workspaceRoot: string,
+  collection: vscode.DiagnosticCollection
+): void {
+  collection.clear();
+  const byFile = new Map<string, PluStanDiagnostic[]>();
+
+  for (const finding of Object.values(state.findings)) {
+    if (finding.status !== "open" && finding.status !== "stale") {
+      continue;
+    }
+    const inspection = inspections.get(finding.inspectionId);
+    const filePath = path.isAbsolute(finding.file) ? finding.file : path.join(workspaceRoot, finding.file);
+    const stalePrefix = finding.status === "stale" ? "(stale) " : "";
+    const summary = inspection ? `${inspection.name} — ${inspection.description}` : "";
+    const diagnostic: PluStanDiagnostic = new vscode.Diagnostic(
+      toRange(finding),
+      `${stalePrefix}[${finding.inspectionId}] ${summary}`.trim(),
+      mapSeverity(inspection?.severity)
+    );
+    diagnostic.source = "plu-stan";
+    diagnostic.code = finding.inspectionId;
+    diagnostic.plustanFingerprint = finding.fingerprint;
+    diagnostic.plustanInspectionId = finding.inspectionId;
+    const list = byFile.get(filePath) ?? [];
+    list.push(diagnostic);
+    byFile.set(filePath, list);
+  }
+  collection.set([...byFile.entries()].map(([f, ds]) => [vscode.Uri.file(f), ds]));
+}
+
+export function toRange(finding: SessionFinding): vscode.Range {
+  const startLine = Math.max(0, finding.startLine - 1);
+  const startCharacter = Math.max(0, finding.startCol - 1);
+  const endLine = Math.max(startLine, finding.endLine - 1);
+  const rawEnd = Math.max(0, finding.endCol - 1);
+  const endCharacter = endLine === startLine ? Math.max(startCharacter + 1, rawEnd) : rawEnd;
+  return new vscode.Range(startLine, startCharacter, endLine, endCharacter);
+}
+
+function mapSeverity(severity: string | undefined): vscode.DiagnosticSeverity {
+  switch (severity) {
+    case "Error": return vscode.DiagnosticSeverity.Error;
+    case "Warning":
+    case "PotentialBug":
+    case "Performance": return vscode.DiagnosticSeverity.Warning;
+    default: return vscode.DiagnosticSeverity.Information;
+  }
+}
+
+export class DismissCodeActionProvider implements vscode.CodeActionProvider {
+  provideCodeActions(
+    _document: vscode.TextDocument,
+    _range: vscode.Range,
+    context: vscode.CodeActionContext
+  ): vscode.CodeAction[] {
+    const actions: vscode.CodeAction[] = [];
+    for (const diagnostic of context.diagnostics as PluStanDiagnostic[]) {
+      if (diagnostic.source !== "plu-stan" || !diagnostic.plustanFingerprint) {
+        continue;
+      }
+      const action = new vscode.CodeAction("Plu-Stan: Dismiss this finding", vscode.CodeActionKind.QuickFix);
+      action.diagnostics = [diagnostic];
+      action.command = {
+        command: "plustan.dismissFinding",
+        title: "Dismiss",
+        arguments: [{ fingerprint: diagnostic.plustanFingerprint, inspectionId: diagnostic.plustanInspectionId }]
+      };
+      actions.push(action);
+    }
+    return actions;
+  }
+}
+```
+
+- [ ] **Step 2: Rewire `src/extension.ts`**
+
+This is a refactor of the existing file; keep `downloadManager.ts` and all binary-resolution logic (`resolveSettings`, `isEffectivelyConfigured`, `maybeAutoCheckForUpdates`, `offerDownload` flow, `maybeRevealOnchainView`, `readSettings`, `saveWorkspaceBeforeRun`, `getWorkspaceFolder*`) exactly as they are. Changes:
+
+1. **Delete** from `extension.ts`: `runPluStanJson`, `spawnCommand`, `parseJsonFromOutput`, `describePluStanFailure`, `isEnoentError`, `runListOnchain`, `runAnalyze`, `publishDiagnostics`, `toRange`, `mapSeverity`, and the `Inspection`/`Observation`/`AnalyzePayload`/`AnalysisSection` interfaces (replaced by `core/schema.ts` and `analyzer/client.ts`).
+2. **Construct** in `activate` (after `output`/`diagnostics`):
+
+```ts
+const folder = ((): vscode.WorkspaceFolder | undefined => {
+  try { return getWorkspaceFolder(); } catch { return undefined; }
+})();
+
+const client = new SpawnAnalyzerClient(
+  () => {
+    const f = getWorkspaceFolder();
+    const settings = resolveSettings(f);
+    return {
+      binaryPath: settings.binaryPath,
+      binaryPrefixArgs: [],
+      cwd: settings.projectDir,
+      hieDir: settings.hieDir,
+      extraArgs: settings.extraArgs
+    };
+  },
+  (line) => output.appendLine(line)
+);
+
+const statusBar = new PluStanStatusBar();
+const findingsTree = new FindingsTreeProvider();
+const detailPanel = new FindingDetailProvider(
+  (finding) => { void controller.dismiss(finding.fingerprint, finding.inspectionId); },
+  (finding) => { void openFinding(finding); }
+);
+
+const controller = new ReviewController(
+  client,
+  new DismissalsStore(folder ?? vscode.workspace.workspaceFolders![0]),
+  statusBar,
+  context.workspaceState,
+  (state, inspections) => {
+    findingsTree.setData(state, inspections);
+    const root = folder?.uri.fsPath ?? "";
+    publishSessionDiagnostics(state, inspections, root, diagnostics);
+  },
+  output
+);
+controller.restore();
+```
+
+3. **Register** the new UI + commands:
+
+```ts
+context.subscriptions.push(
+  statusBar,
+  controller,
+  vscode.window.registerTreeDataProvider("plustanFindings", findingsTree),
+  vscode.window.registerWebviewViewProvider(FindingDetailProvider.viewId, detailPanel),
+  vscode.languages.registerCodeActionsProvider(
+    { language: "haskell", scheme: "file" },
+    new DismissCodeActionProvider(),
+    { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] }
+  ),
+  vscode.commands.registerCommand("plustan.startReview", async (scopeArg?: "all" | string[]) => {
+    if (!await saveWorkspaceBeforeRun()) { return; }
+    const f = getWorkspaceFolderOrNotify();
+    if (!f) { return; }
+    const settings = await ensureBinaryConfigured(f, provider, resolveSettings);
+    if (!settings) { return; }
+    await controller.startReview(scopeArg);
+  }),
+  vscode.commands.registerCommand("plustan.endReview", () => controller.endReview()),
+  vscode.commands.registerCommand("plustan.toggleFindingsGrouping", () => findingsTree.toggleGrouping()),
+  vscode.commands.registerCommand("plustan.openFinding", async (item?: FindingTreeItem) => {
+    if (!item) { return; }
+    detailPanel.showFinding(item.finding, controller.inspectionDocs.get(item.finding.inspectionId));
+    await openFinding(item.finding);
+  }),
+  vscode.commands.registerCommand("plustan.dismissFinding",
+    async (arg?: FindingTreeItem | { fingerprint: string; inspectionId: string }) => {
+      const target = arg instanceof FindingTreeItem
+        ? { fingerprint: arg.finding.fingerprint, inspectionId: arg.finding.inspectionId }
+        : arg;
+      if (!target) { return; }
+      const note = await vscode.window.showInputBox({
+        prompt: "Optional note: why is this finding not applicable?",
+        placeHolder: "e.g. credential-only comparison is intentional here"
+      });
+      await controller.dismiss(target.fingerprint, target.inspectionId, note || undefined);
+    }),
+  vscode.commands.registerCommand("plustan.undismissFinding", async (item?: FindingTreeItem) => {
+    if (item) { await controller.undismiss(item.finding.fingerprint); }
+  })
+);
+
+async function openFinding(finding: SessionFinding): Promise<void> {
+  const f = getWorkspaceFolder();
+  const filePath = path.isAbsolute(finding.file) ? finding.file : path.join(f.uri.fsPath, finding.file);
+  const doc = await vscode.workspace.openTextDocument(filePath);
+  const editor = await vscode.window.showTextDocument(doc, { preserveFocus: false });
+  const range = toRange(finding);
+  editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+  editor.selection = new vscode.Selection(range.start, range.start);
+}
+```
+
+4. **Rework the legacy commands** `plustan.runWorkspace` / `plustan.runModule`: keep them registered, but implement as one-shot runs through `client.analyze(...)` that publish diagnostics via a throwaway one-run `SessionState` (`reduceSession(reduceSession(initialSessionState, {type:"sessionStarted", startedAt: new Date().toISOString()}), {type:"runCompleted", coveredFiles:[...], observations: payload.observations, dismissedFingerprints: [...]})`) — no session is started, no auto-rerun armed. `plustan.refreshOnchainModules` switches to `client.listOnchain()`. The old `OnchainModulesProvider` stays as the provider for the (now secondary) `plustanOnchainModules` view; drop its `ActionItem` rows (Start/End/Refresh now live in the `view/title` menus) but keep the `MessageItem` unconfigured-binary hint.
+5. Imports to add at the top of `extension.ts`:
+
+```ts
+import { SpawnAnalyzerClient } from "./analyzer/client";
+import { ReviewController } from "./session/controller";
+import { DismissalsStore } from "./session/dismissalsStore";
+import { FindingsTreeProvider, FindingTreeItem } from "./ui/findingsTree";
+import { FindingDetailProvider } from "./ui/detailPanel";
+import { PluStanStatusBar } from "./ui/statusBar";
+import { DismissCodeActionProvider, publishSessionDiagnostics, toRange } from "./diagnostics";
+import { SessionFinding, initialSessionState, reduceSession } from "./core/sessionState";
+```
+
+- [ ] **Step 3: Compile and run unit tests** — `npm run compile && npm run test:unit` → clean, all PASS.
+
+- [ ] **Step 4: Manual smoke in the Extension Development Host**
+
+Launch: `code --extensionDevelopmentPath=$PWD/vscode-plustan <a plutus workspace>` (or the `cursor` equivalent). Verify: Start Review appears in the Findings view title → starting runs an analysis → findings appear grouped → clicking one opens the file and fills the detail panel → dismiss persists to `.plustan/dismissals.json` → saving an onchain file re-runs → status bar updates.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode-plustan/src/extension.ts vscode-plustan/src/diagnostics.ts
+git commit -m "feat(ext): wire review cockpit into extension activation"
+```
+
+---
+
+### Task 15: Integration smoke test (@vscode/test-electron)
+
+**Files:**
+- Create: `vscode-plustan/src/test/runTest.ts`, `vscode-plustan/src/test/suite/index.ts`, `vscode-plustan/src/test/suite/session.test.ts`
+- Create: `vscode-plustan/test-fixtures/fake-plustan` (shell shim), `vscode-plustan/test-fixtures/workspace/` fixture
+- Modify: `vscode-plustan/package.json`
+
+- [ ] **Step 1: Install harness**
+
+```bash
+cd vscode-plustan && npm install --save-dev @vscode/test-electron@^2.4.0
+```
+
+Add script: `"test:integration": "npm run compile && node out/test/runTest.js"`.
+
+- [ ] **Step 2: Create the executable shim** `test-fixtures/fake-plustan`:
+
+```bash
+#!/usr/bin/env bash
+exec node "$(dirname "$0")/fake-plustan.js" "$@"
+```
+
+Then: `chmod +x vscode-plustan/test-fixtures/fake-plustan` (git preserves the executable bit).
+
+- [ ] **Step 3: Create the fixture workspace**
+
+- `test-fixtures/workspace/src/Fixture/Validator.hs`:
+
+```haskell
+module Fixture.Validator where
+{-# ANN module ("onchain-contract" :: String) #-}
+
+validator :: Bool
+validator = True
+```
+
+- `test-fixtures/workspace/.vscode/settings.json`:
+
+```json
+{ "plustan.binaryPath": "${workspaceFolder}/../fake-plustan" }
+```
+
+**Note:** VS Code does not expand `${workspaceFolder}` in arbitrary settings — the extension reads the raw string. `readSettings` must therefore expand a leading `${workspaceFolder}` itself; add to `readSettings` in `extension.ts`:
+
+```ts
+const rawBinaryPath = config.get<string>("binaryPath", "").trim();
+const binaryPath = rawBinaryPath.replace("${workspaceFolder}", folder.uri.fsPath);
+```
+
+(One-line behavior improvement, also useful to real users; mention it in the README table for `plustan.binaryPath`.)
+
+- [ ] **Step 4: Write the harness**
+
+`src/test/runTest.ts`:
+
+```ts
+import * as path from "node:path";
+import { runTests } from "@vscode/test-electron";
+
+async function main(): Promise<void> {
+  const extensionDevelopmentPath = path.resolve(__dirname, "..", "..");
+  const extensionTestsPath = path.resolve(__dirname, "suite", "index");
+  const workspace = path.resolve(extensionDevelopmentPath, "test-fixtures", "workspace");
+  await runTests({
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs: [workspace, "--disable-extensions"]
+  });
+}
+
+main().catch((err) => {
+  console.error("Integration tests failed:", err);
+  process.exit(1);
+});
+```
+
+`src/test/suite/index.ts`:
+
+```ts
+import * as path from "node:path";
+// require-form import: works regardless of the tsconfig's esModuleInterop setting
+import Mocha = require("mocha");
+
+export function run(): Promise<void> {
+  const mocha = new Mocha({ ui: "bdd", timeout: 60_000, color: true });
+  mocha.addFile(path.resolve(__dirname, "session.test.js"));
+  return new Promise((resolve, reject) => {
+    mocha.run((failures) => (failures > 0 ? reject(new Error(`${failures} tests failed`)) : resolve()));
+  });
+}
+```
+
+`src/test/suite/session.test.ts`:
+
+```ts
+import * as assert from "node:assert";
+import * as vscode from "vscode";
+
+async function poll<T>(fn: () => T | undefined, timeoutMs = 30_000): Promise<T> {
+  const start = Date.now();
+  for (;;) {
+    const value = fn();
+    if (value !== undefined) {
+      return value;
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("poll timed out");
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+}
+
+describe("review session (integration)", () => {
+  it("start review produces diagnostics from the stub binary", async () => {
+    // "all" skips the module-scope QuickPick (which would block a headless test)
+    await vscode.commands.executeCommand("plustan.startReview", "all");
+    const diags = await poll(() => {
+      const all = vscode.languages.getDiagnostics()
+        .flatMap(([, ds]) => ds)
+        .filter((d) => d.source === "plu-stan");
+      return all.length >= 2 ? all : undefined;
+    });
+    assert.strictEqual(diags.length, 2);
+    assert.ok(diags[0].message.includes("PLU-STAN-04"));
+  });
+});
+```
+
+- [ ] **Step 5: Run** — `cd vscode-plustan && npm run test:integration`
+Expected: downloads a VS Code build once, then `1 passing`.
+
+If `plustan.startReview` stalls on the binary-configured guard: the fixture settings provide `plustan.binaryPath`, so `ensureBinaryConfigured` passes; if the run instead fails on workspace-save, the fixture has no dirty editors, so `saveWorkspaceBeforeRun` returns true. Debug via the `Plu-Stan` output channel content printed in the test console.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vscode-plustan/src/test vscode-plustan/test-fixtures vscode-plustan/package.json vscode-plustan/package-lock.json
+git commit -m "test(ext): integration smoke test with stub plustan binary"
+```
+
+---
+
+### Task 16: Docs, versions, final verification
+
+**Files:**
+- Modify: `vscode-plustan/package.json` (version), `vscode-plustan/README.md`, `vscode-plustan/MARKETPLACE.md`, `CHANGELOG.md`
+
+- [ ] **Step 1: Docs**
+
+- `vscode-plustan/package.json`: `"version": "0.3.0"`.
+- `vscode-plustan/README.md`: replace the Features section with the review-session workflow (Start Review → findings tree → detail panel → dismiss → auto re-run on save → End Review); document `.plustan/dismissals.json` (commit it to share dismissals); document the new commands and the `${workspaceFolder}` expansion in `plustan.binaryPath`; note that extension 0.3.x requires plustan ≥ 0.2.5.0 (schema v2) and that "Check for Updates" fetches it.
+- `vscode-plustan/MARKETPLACE.md`: same feature-list refresh, marketing tone.
+- Repo `CHANGELOG.md`: extension 0.3.0 entry.
+
+- [ ] **Step 2: Full verification**
+
+```bash
+cabal build exe:plustan && cabal test --test-show-details=direct 2>&1 | tail -5
+cd vscode-plustan && npm run compile && npm run test:unit && npm run test:integration
+```
+Expected: everything green. Also do one manual end-to-end pass against a real Plutus workspace with the locally built binary (`cabal list-bin exe:plustan` → set `plustan.binaryPath`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add vscode-plustan/package.json vscode-plustan/README.md vscode-plustan/MARKETPLACE.md CHANGELOG.md
+git commit -m "docs: review-cockpit workflow docs; extension v0.3.0"
+```
+
+---
+
+## Out of scope for this plan (later phases)
+
+- Backend-computed quick fixes (`fix` field) — Phase 2.
+- Ask-AI handoff adapters — Phase 3.
+- CLI reading `.plustan/dismissals.json` for CI parity — Phase 3.
+- Daemon backend / LSP — deliberately excluded by the spec.

--- a/docs/superpowers/specs/2026-07-06-vscode-review-cockpit-design.md
+++ b/docs/superpowers/specs/2026-07-06-vscode-review-cockpit-design.md
@@ -194,3 +194,17 @@ Three independently shippable phases; each is roughly one implementation plan.
 - LSP server / multi-editor support.
 - Auditor-oriented triage states and exportable reports.
 - MCP/agent integration.
+
+## Known limitations (Phase 1)
+
+- **Duplicate-fingerprint dismissal migration.** When two byte-identical findings
+  of the same rule occur in one module, they share a base fingerprint and are
+  disambiguated only by a run-local `#2`, `#3`… suffix assigned in span order
+  (`uniquifyFingerprints`). Dismissals are keyed on the fingerprint string alone,
+  so if the user dismisses the first occurrence (bare `FPR-…`) and then edits or
+  fixes it, on the next run the surviving twin inherits the bare fingerprint and
+  is silently auto-marked dismissed — a false negative for a finding that was
+  never triaged. Trigger is narrow and it is recoverable (undismiss). Phase 2
+  hardening: key dismissals on `inspectionId` + span (or anchor base fingerprints
+  positionally) rather than the bare fingerprint. Surfaced by the whole-branch
+  review, 2026-07-07.

--- a/docs/superpowers/specs/2026-07-06-vscode-review-cockpit-design.md
+++ b/docs/superpowers/specs/2026-07-06-vscode-review-cockpit-design.md
@@ -1,0 +1,196 @@
+# Plu-Stan VS Code Extension: Review Cockpit — Design
+
+**Date:** 2026-07-06
+**Status:** Approved design, pending implementation plan
+**Scope:** Evolution of `vscode-plustan` (currently a v0.2.2 MVP CLI wrapper) plus the backend JSON contract changes it requires.
+
+## Problem
+
+The current extension is a thin CLI wrapper: the user manually clicks "Run", the extension spawns `plustan`, and findings land in the Problems panel as bare `[PLU-STAN-XX] Rule name` messages. There is no re-run loop, no explanation of what a rule means or why it matters on-chain, no way to dismiss a false positive that survives re-runs, no tracking of progress, and no staleness signal when code changes after a run.
+
+## Product decisions (from brainstorm)
+
+- **Usage model:** on-demand review (audit cockpit), not an always-on linter. The user deliberately reviews a contract at milestones.
+- **Primary user:** the contract author self-reviewing before commit/deploy. Deliverable of a session is fixed code, not a report. Dismissals are informal (no justification workflow), but persist.
+- **Fix loop:** rich in-editor explanations, quick-fix code actions where mechanical, one-click dismiss, and AI handoff are all in scope (phased).
+- **Re-run model:** auto re-run on save, gated by an explicit **review session** — outside a session, no surprise builds ever.
+- **Primary surface:** findings tree in the Plu-Stan sidebar + a detail panel for the selected finding. Squiggles/Problems remain secondary surfaces.
+- **Architecture:** evolve the spawn-per-run CLI wrapper (Approach A), with the extension↔analyzer boundary shaped so a future daemon backend is a transport swap, not a redesign.
+
+## Architecture
+
+Two components, one repo:
+
+- **TypeScript extension** — owns all session state, UX, dismissal storage, and run orchestration.
+- **`plustan` CLI** — stays a stateless, spawn-per-request analyzer emitting JSON on stdout.
+
+All extension↔analyzer traffic goes through one TS interface:
+
+```ts
+interface AnalyzerClient {
+  capabilities(): Promise<Capabilities>;         // schema version + features
+  listOnchain(): Promise<ListOnchainPayload>;
+  analyze(scope: RunScope): Promise<AnalyzePayload>;  // scope: workspace | module
+}
+```
+
+`SpawnAnalyzerClient` (spawn-per-run, today) is the first implementation; a future `DaemonAnalyzerClient` is the second. Nothing above this interface may assume a process-per-request model.
+
+### Backend contract changes (JSON schema v2)
+
+1. **Rich inspection docs.** Each inspection carries its full teaching content:
+   `description`, `whyItMatters` (the Plinth/on-chain rationale), `badExample` and
+   `goodExample` code blocks, `remediation` steps, and a docs anchor into the rules
+   documentation. The analyzer binary is the single source of truth for rule
+   content; the extension is a renderer. Extension and rule versions cannot drift.
+
+2. **Stable finding fingerprints.** Current observation IDs embed line:col, so any
+   edit above a finding changes its identity. New `fingerprint` field per
+   observation: `hash(inspectionId, moduleName, sourceTextOfFlaggedSpan)`.
+   Properties: survives edits elsewhere in the file; changes when the flagged
+   expression itself changes (correct — a changed expression deserves re-triage).
+   Fingerprints are the key for dismissals and for open/fixed tracking across runs.
+   Duplicate fingerprints within one run (identical flagged text, same module, same
+   rule) are disambiguated by an occurrence index appended in span order.
+
+3. **Capabilities handshake.** New `plustan capabilities --json` subcommand
+   returning `{schemaVersion, features: [...]}`. The extension calls it once per
+   session; on schema mismatch it prompts to update the binary (existing download
+   manager flow) instead of failing mid-run with a JSON parse error.
+
+4. **Backend-computed fixes (Phase 2).** When a rule can produce a mechanically
+   safe rewrite, its observation carries `fix: {span, replacement, title}`.
+   Fixes are computed in Haskell (which has the AST) and applied in TypeScript as a
+   `WorkspaceEdit`. The extension never rewrites Haskell source itself.
+
+### Dismissal storage
+
+`.plustan/dismissals.json` in the workspace root — extension-managed,
+repo-committable:
+
+```json
+{ "version": 1,
+  "dismissals": [
+    { "fingerprint": "…", "inspectionId": "PLU-STAN-04",
+      "note": "credential-only check is intentional here", "dismissedAt": "2026-07-06T10:00:00Z" }
+  ] }
+```
+
+Phase 1: the extension filters dismissed findings client-side after each run.
+Phase 3: the CLI learns to read the same file so CI runs agree with the editor.
+Stan's native `.stan.toml` observation ignores are deliberately not used: they are
+position-based and break on edit.
+
+### Run orchestration
+
+During an active session: file save → debounce ~500 ms → `analyze(module)` for the
+saved module (the CLI auto-builds as it already does). A newer save for the same
+scope cancels/coalesces the in-flight run. One run executes at a time; module runs
+queue behind a workspace run. Outside a session, saves trigger nothing.
+
+## Review session & UX components
+
+### Session state machine
+
+`idle → active → ended`. Started from the sidebar ("Start Review") or the command
+palette; scoped to the workspace or a chosen set of onchain modules. While active:
+
+- auto re-run on save is armed;
+- each finding carries a status: **open**, **fixed** (present in a prior run,
+  absent from the latest run of its module), **dismissed**, or **stale** (its file
+  was edited since the run that produced it);
+- session state (findings, statuses, run count, started-at) persists in VS Code
+  workspace storage, so a window reload resumes the review.
+
+A status bar item shows `Plu-Stan: 8 open · 3 fixed` with a spinner while a run is
+in flight. Ending the session disarms auto-runs and writes a plain-text summary to
+the output channel.
+
+### Findings tree
+
+Replaces the module list as the sidebar centerpiece (modules remain a secondary
+collapsed section). Default grouping: severity → rule → finding (`file:line —
+snippet`); one toggle regroups by module. Stale findings render dimmed with a `~`
+marker. Fixed findings move to a collapsed "Fixed this session" node so progress is
+visible. Inline per-finding icons: open file, dismiss, ask AI.
+
+### Detail panel
+
+A webview view docked in the Plu-Stan sidebar below the tree. Selecting a finding
+(tree click, or the cursor landing on a plu-stan squiggle) renders: rule
+ID/name/severity/category · why it matters on-chain · bad/good example blocks · the
+flagged snippet · action buttons **[Quick Fix] [Dismiss] [Ask AI] [Rule docs]**.
+The panel renders schema-v2 payload content only — it holds no rule knowledge of
+its own.
+
+### Diagnostics & code actions
+
+Squiggles and the Problems panel stay, with the rule's one-line summary added to
+the message. A `CodeActionProvider` attaches to every plu-stan diagnostic:
+
+- *Dismiss this finding* — always offered; appends to `.plustan/dismissals.json`.
+- *Ask AI* — always offered (see below).
+- *Quick Fix: <title>* — offered when the observation carries a backend `fix`;
+  applies it as a `WorkspaceEdit`. First candidate rule: PLU-STAN-08 (make
+  non-strict binding strict with a bang pattern); further rules added only when the
+  rewrite is provably mechanical.
+
+### AI handoff
+
+*Ask AI* assembles a self-contained markdown bundle: rule doc, flagged code with
+`file:line`, surrounding function context, and an instruction to propose a fix
+preserving validator semantics. Delivery adapters, tried in order:
+
+1. Copilot Chat (`workbench.action.chat.open` with the bundle as query) when available;
+2. Cursor chat when the Cursor environment is detected;
+3. clipboard fallback (always works), with a toast confirming the copy;
+4. a user-configurable command hook (`plustan.aiHandoffCommand`) for other assistants.
+
+Future direction, explicitly out of scope for this spec: exposing plustan as an MCP
+tool so agents can run analyses themselves (connects to the `plugins/` skill
+experiments).
+
+## Error handling
+
+- **Broken builds are the normal case** in a fix loop. Build fails on save-triggered
+  run → keep findings (marked stale), status bar shows `build failed — results
+  stale`, compiler output goes to the output channel, next save retries. No modal
+  errors during a session.
+- **Schema drift** → caught by the capabilities handshake at session start, with an
+  "update binary" prompt (existing download manager).
+- **GHC/.hie mismatch, panics, no-JSON output** → existing classification in
+  `describePluStanFailure` is kept.
+- **Binary missing** → existing offer-download flow is kept.
+
+## Testing
+
+- **Extension unit tests (mocha, no VS Code host):** session reducer transitions,
+  fingerprint matching (open/fixed/stale), dismissal filtering, JSON schema-v2
+  parsing. These are pure functions by construction.
+- **Extension integration tests (`@vscode/test-electron`):** run against the repo's
+  existing `target/` fixture project — start session → run → dismiss a finding →
+  edit a file → save → assert statuses and tree contents.
+- **Backend (cabal test suite):** golden tests for schema-v2 JSON output, the
+  capabilities payload, fingerprint stability under unrelated edits, and each
+  backend-computed fix.
+
+## Phasing
+
+Three independently shippable phases; each is roughly one implementation plan.
+
+1. **Phase 1 — the cockpit.** Backend: schema v2 (rich docs, fingerprints),
+   capabilities handshake. Extension: `AnalyzerClient` refactor, session state
+   machine, findings tree, detail panel, dismissals, staleness, auto-rerun-on-save,
+   status bar. Delivers the core experience on its own.
+2. **Phase 2 — quick fixes.** Backend `fix` emission for mechanically safe rules;
+   extension code actions + `WorkspaceEdit` application.
+3. **Phase 3 — AI handoff + CI parity.** Ask-AI adapters; CLI reads
+   `.plustan/dismissals.json`.
+
+## Out of scope
+
+- Daemon backend / incremental analysis (revisit if save→results latency proves
+  painful; the `AnalyzerClient` seam exists for it).
+- LSP server / multi-editor support.
+- Auditor-oriented triage states and exportable reports.
+- MCP/agent integration.

--- a/src/Stan/Observation.hs
+++ b/src/Stan/Observation.hs
@@ -16,6 +16,10 @@ module Stan.Observation
     , mkObservation
     , mkObservationId
 
+      -- * Fingerprinting
+    , observationFingerprint
+    , observationSpanText
+
     , ignoredObservations
 
       -- * Pretty print
@@ -274,6 +278,55 @@ mkObservationId insId moduleName srcSpan = Id $ Text.intercalate "-"
     , show (srcSpanStartLine srcSpan) <> ":" <> show (srcSpanStartCol srcSpan)
     ]
 
+{- | The source text of the flagged span, column-trimmed on the first
+and last line. GHC end columns are exclusive. Missing lines (file
+content shorter than the span) contribute @""@.
+-}
+observationSpanText :: Observation -> Text
+observationSpanText Observation{..} =
+    Text.intercalate "\n" (trimCols spanLines)
+  where
+    startL, endL, startC, endC :: Int
+    startL = srcSpanStartLine observationSrcSpan
+    endL   = srcSpanEndLine observationSrcSpan
+    startC = srcSpanStartCol observationSrcSpan
+    endC   = srcSpanEndCol observationSrcSpan
+
+    spanLines :: [Text]
+    spanLines =
+        [ maybe "" decodeUtf8 (BS.lines observationFileContent !!? (ln - 1))
+        | ln <- [startL .. endL]
+        ]
+
+    trimCols :: [Text] -> [Text]
+    trimCols [] = []
+    trimCols [single] =
+        [Text.take (endC - startC) (Text.drop (startC - 1) single)]
+    trimCols (firstLine : rest) =
+        Text.drop (startC - 1) firstLine : trimLast rest
+
+    trimLast :: [Text] -> [Text]
+    trimLast [] = []
+    trimLast [lastLine] = [Text.take (endC - 1) lastLine]
+    trimLast (l : ls) = l : trimLast ls
+
+{- | Position-independent identity for an 'Observation':
+
+@
+FPR-<INSPECTION-ID>-<module-hash-6>-<span-text-hash-10>
+@
+
+Stable under edits elsewhere in the file; changes when the flagged
+expression itself changes (which correctly forces re-triage).
+-}
+observationFingerprint :: Observation -> Text
+observationFingerprint o = Text.intercalate "-"
+    [ "FPR"
+    , unId (observationInspectionId o)
+    , hashModuleName (observationModuleName o)
+    , hashText 10 (observationSpanText o)
+    ]
+
 #if MIN_VERSION_base64(1,0,0)
 extractBase64 :: Data.Base64.Types.Base64 k a -> a
 extractBase64 = Data.Base64.Types.extractBase64
@@ -281,6 +334,15 @@ extractBase64 = Data.Base64.Types.extractBase64
 extractBase64 :: a -> a
 extractBase64 = id
 #endif
+
+-- | SHA1 + base64, truncated to @n@ characters.
+hashText :: Int -> Text -> Text
+hashText n =
+    Text.take n
+    . extractBase64
+    . Base64.encodeBase64
+    . SHA1.hash
+    . encodeUtf8
 
 {- | Hash module name to a short string of length @6@. Hashing
 algorithm is the following:
@@ -290,10 +352,4 @@ algorithm is the following:
 3. Last, take first @6@ characters.
 -}
 hashModuleName :: ModuleName -> Text
-hashModuleName =
-    Text.take 6
-    . extractBase64
-    . Base64.encodeBase64
-    . SHA1.hash
-    . encodeUtf8
-    . unModuleName
+hashModuleName = hashText 6 . unModuleName

--- a/src/Stan/Plinth/Docs.hs
+++ b/src/Stan/Plinth/Docs.hs
@@ -98,19 +98,20 @@ plinthDocsMap = fromList
               , "is usually deconstructed immediately afterwards, paying execution units for"
               , "nothing. Worse, defaulting with 'fromMaybe' silently substitutes a value in"
               , "exactly the cases where a validator should reject the transaction, so a"
-              , "\"not found\" turns into a successful validation with a bogus value. Fast-fail"
-              , "recursion (or continuation-passing) is both cheaper and safer."
+              , "\"not found\" turns into a successful validation with a bogus value. Explicit"
+              , "fast-fail matching (or continuation-passing) is both cheaper and safer."
               ]
           , docsBadExample = Text.unlines
-              [ "-- allocates a Maybe just to unwrap it, and 'find' is a higher-order helper"
-              , "ownInput = fromMaybe (traceError \"no input\") (find isOwn inputs)"
+              [ "-- a missing value silently becomes 0 and validation \"succeeds\" on garbage"
+              , "total = fromMaybe 0 (lookupValue token outputs)"
               ]
           , docsGoodExample = Text.unlines
-              [ "-- specialized fast-fail search: no Maybe allocation, one traversal"
-              , "ownInput = go inputs"
-              , "  where"
-              , "    go []       = traceError \"no input\""
-              , "    go (i : is) = if isOwn i then i else go is"
+              [ "-- fail fast: a missing value must reject the transaction"
+              , "-- (traceError is safe inside a case branch; Plinth's strict application"
+              , "--  means it would fire eagerly in an argument position like fromMaybe's)"
+              , "total = case lookupValue token outputs of"
+              , "  Nothing -> traceError \"token value missing\""
+              , "  Just v  -> v"
               ]
           , docsAnchor = "optional-types"
           }
@@ -118,10 +119,13 @@ plinthDocsMap = fromList
     , ( Id "PLU-STAN-04"
       , InspectionDocs
           { docsWhyItMatters = Text.unlines
-              [ "Comparing only a PubKeyHash, ScriptHash, or Credential checks the payment"
-              , "part of an address and ignores the staking part. An attacker can construct"
-              , "an output that passes the credential check while redirecting the staking"
-              , "rewards of the locked value to their own stake key — staking value theft."
+              [ "When the hash is drawn from an output's address, comparing only a"
+              , "PubKeyHash, ScriptHash, or Credential checks the payment part of that"
+              , "address and ignores the staking part. An attacker can construct an output"
+              , "that passes the credential check while redirecting the staking rewards of"
+              , "the locked value to their own stake key — staking value theft. The rule"
+              , "also fires on legitimate uses (e.g. 'txInfoSignatories' membership checks);"
+              , "those can be reviewed and suppressed."
               ]
           , docsBadExample = Text.unlines
               [ "-- only the payment credential is compared"
@@ -239,7 +243,7 @@ plinthDocsMap = fromList
               [ "'valueOf' inspects a single currency/token entry, so a comparison built on"
               , "it says nothing about the rest of the Value. An output can satisfy"
               , "'valueOf out cs tn >= n' while also carrying any number of unexpected dust"
-              , "tokens (a Dusk-token attack when the token set is unbounded), and"
+              , "tokens (a dust token attack when the token set is unbounded), and"
               , "lovelace-only checks silently depend on the min-UTxO requirement, which is a"
               , "protocol parameter that changes over time. Compare whole values, or bound"
               , "the token set explicitly."

--- a/src/Stan/Plinth/Docs.hs
+++ b/src/Stan/Plinth/Docs.hs
@@ -1,0 +1,517 @@
+{- |
+Copyright: (c) 2026 IOHK
+SPDX-License-Identifier: MPL-2.0
+
+Teaching content for the PLU-STAN inspections, rendered by the
+VS Code extension's finding detail panel. The analyzer binary is the
+single source of truth for this content — the extension only renders it.
+-}
+
+module Stan.Plinth.Docs
+    ( InspectionDocs (..)
+    , lookupDocs
+    , plinthDocsMap
+    ) where
+
+import Stan.Core.Id (Id (..))
+import Stan.Inspection (Inspection)
+
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as Text
+
+
+-- | Extended, Plinth-specific documentation for one inspection.
+data InspectionDocs = InspectionDocs
+    { docsWhyItMatters :: !Text
+      -- ^ The on-chain rationale: what goes wrong and who exploits it.
+    , docsBadExample   :: !Text
+      -- ^ A short Haskell snippet showing the flagged pattern.
+    , docsGoodExample  :: !Text
+      -- ^ The corrected version of the same snippet.
+    , docsAnchor       :: !Text
+      -- ^ Anchor into RULES.md (e.g. \"equality\"); @\"\"@ if none.
+    } deriving stock (Show, Eq)
+
+lookupDocs :: Id Inspection -> Maybe InspectionDocs
+lookupDocs insId = HM.lookup insId plinthDocsMap
+
+plinthDocsMap :: HashMap (Id Inspection) InspectionDocs
+plinthDocsMap = fromList
+    [ ( Id "PLU-STAN-01"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "The signature builtins only prove that a signature matches a message and a"
+              , "public key — they say nothing about which transaction the message authorizes."
+              , "If the message is supplied by the redeemer and does not commit to this"
+              , "specific spend (a nonce, the spent TxOutRef, a hash the script recomputes"
+              , "on-chain), anyone who has seen one valid signature can replay it in a new"
+              , "transaction and re-run the authorized action as often as they like."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- the redeemer supplies both message and signature: the same signed"
+              , "-- blob authorizes this action in every future transaction (replay)"
+              , "checkAuth (msg, sig) = verifyEd25519Signature ownerKey msg sig"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- the message is rebuilt on-chain and commits to the spent UTxO,"
+              , "-- so a captured signature is useless in any other transaction"
+              , "checkAuth sig ownRef ="
+              , "  let msg = serialiseData (toBuiltinData ownRef)"
+              , "  in verifyEd25519Signature ownerKey msg sig"
+              ]
+          , docsAnchor = "data-handling--deserialization"
+          }
+      )
+    , ( Id "PLU-STAN-02"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "'unsafeFromBuiltinData' eagerly decodes the whole BuiltinData blob into a"
+              , "sums-of-products value. An attacker who controls the datum can attach a huge"
+              , "or deeply nested blob so that decoding alone blows the execution budget and"
+              , "the script can never run — an unbounded datum spam attack. Even on honest"
+              , "data the full SOP conversion is one of the most expensive things a Plinth"
+              , "script can do; inspecting only the needed fields on the raw BuiltinData is"
+              , "far cheaper."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- decodes the entire datum, however large the attacker made it"
+              , "validate d _redeemer _ctx ="
+              , "  let LoanDatum{owner, amount} = unsafeFromBuiltinData d"
+              , "  in checkTerms owner amount"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- walk the BuiltinData directly and touch only the needed fields"
+              , "-- (BI = PlutusTx.Builtins.Internal)"
+              , "validate d _redeemer _ctx ="
+              , "  let fields = BI.snd (BI.unsafeDataAsConstr d)"
+              , "      owner  = BI.unsafeDataAsB (BI.head fields)"
+              , "      amount = BI.unsafeDataAsI (BI.head (BI.tail fields))"
+              , "  in checkTerms owner amount"
+              ]
+          , docsAnchor = "data-handling--deserialization"
+          }
+      )
+    , ( Id "PLU-STAN-03"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "Every 'Maybe' produced on-chain allocates a 'Just'/'Nothing' constructor that"
+              , "is usually deconstructed immediately afterwards, paying execution units for"
+              , "nothing. Worse, defaulting with 'fromMaybe' silently substitutes a value in"
+              , "exactly the cases where a validator should reject the transaction, so a"
+              , "\"not found\" turns into a successful validation with a bogus value. Fast-fail"
+              , "recursion (or continuation-passing) is both cheaper and safer."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- allocates a Maybe just to unwrap it, and 'find' is a higher-order helper"
+              , "ownInput = fromMaybe (traceError \"no input\") (find isOwn inputs)"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- specialized fast-fail search: no Maybe allocation, one traversal"
+              , "ownInput = go inputs"
+              , "  where"
+              , "    go []       = traceError \"no input\""
+              , "    go (i : is) = if isOwn i then i else go is"
+              ]
+          , docsAnchor = "optional-types"
+          }
+      )
+    , ( Id "PLU-STAN-04"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "Comparing only a PubKeyHash, ScriptHash, or Credential checks the payment"
+              , "part of an address and ignores the staking part. An attacker can construct"
+              , "an output that passes the credential check while redirecting the staking"
+              , "rewards of the locked value to their own stake key — staking value theft."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- only the payment credential is compared"
+              , "paysToOwner out = addressCredential (txOutAddress out) == ownerCredential"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- the full Address (payment + staking) is compared"
+              , "paysToOwner out = txOutAddress out == ownerAddress"
+              ]
+          , docsAnchor = "equality"
+          }
+      )
+    , ( Id "PLU-STAN-05"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "Higher-order helpers such as 'all', 'any', 'find', 'filter', and 'foldr'"
+              , "compile to UPLC that builds and applies a closure for the predicate on every"
+              , "element, and the Foldable-polymorphic versions add dictionary overhead on"
+              , "top. Those execution units are paid by every user on every invocation of"
+              , "your validator, and on large input/output lists they can push a legitimate"
+              , "transaction over the execution budget. A specialized recursive function"
+              , "inlines the predicate and eliminates the closure traffic."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- 'any' applies the lambda closure to each element"
+              , "paidEnough outs = any (\\o -> txOutValue o `geq` price) outs"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- specialized recursion: the predicate is inlined into the loop"
+              , "paidEnough = go"
+              , "  where"
+              , "    go []       = False"
+              , "    go (o : os) = if txOutValue o `geq` price then True else go os"
+              ]
+          , docsAnchor = "higher-order-functions"
+          }
+      )
+    , ( Id "PLU-STAN-06"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "Composing traversals such as 'map' over 'filter' walks the list twice and"
+              , "materializes an intermediate list in between; UPLC has no fusion, so every"
+              , "extra pass and every intermediate cons cell is billed as CPU and memory"
+              , "execution units. On transaction input/output lists this multiplies the cost"
+              , "of one of the hottest paths in a validator. Fusing the passes into a single"
+              , "recursive function does the same work in one traversal with no intermediate"
+              , "allocation."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- two passes plus an intermediate list"
+              , "scriptOuts = map txOutValue (filter isScriptOut (txInfoOutputs info))"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- one fused pass, no intermediate list"
+              , "scriptOuts = go (txInfoOutputs info)"
+              , "  where"
+              , "    go []       = []"
+              , "    go (o : os) ="
+              , "      if isScriptOut o then txOutValue o : go os else go os"
+              ]
+          , docsAnchor = "higher-order-functions"
+          }
+      )
+    , ( Id "PLU-STAN-07"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "GHC desugars guards into nested pattern-match fall-through chains, and the"
+              , "Plinth compiler turns those into deeper, more expensive UPLC than a plain"
+              , "if-then-else expresses. The redundant match scaffolding costs execution"
+              , "units on every single invocation of the validator — a pure waste, since the"
+              , "same logic written with explicit conditionals compiles to a flat, cheap"
+              , "chain of 'ifThenElse' calls."
+              ]
+          , docsBadExample = Text.unlines
+              [ "tier n"
+              , "  | n <= 10   = 1"
+              , "  | n <= 100  = 2"
+              , "  | otherwise = 3"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "tier n ="
+              , "  if n <= 10 then 1"
+              , "  else if n <= 100 then 2"
+              , "  else 3"
+              ]
+          , docsAnchor = "guards"
+          }
+      )
+    , ( Id "PLU-STAN-08"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "In Plinth a non-strict let binding is compiled as a delayed computation, so"
+              , "a binding that is referenced several times can be re-evaluated at every use"
+              , "site in the generated UPLC. If the bound expression is expensive — say,"
+              , "summing 'valueSpent' over all inputs — you pay its full cost once per"
+              , "reference instead of once per transaction. A bang pattern forces one shared"
+              , "evaluation up front."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- 'total' may be recomputed at each of its two use sites"
+              , "let total = valueSpent info"
+              , "in total `geq` minDeposit && total `geq` minCollateral"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- forced once, shared by both checks"
+              , "let !total = valueSpent info"
+              , "in total `geq` minDeposit && total `geq` minCollateral"
+              ]
+          , docsAnchor = "bindings"
+          }
+      )
+    , ( Id "PLU-STAN-09"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "'valueOf' inspects a single currency/token entry, so a comparison built on"
+              , "it says nothing about the rest of the Value. An output can satisfy"
+              , "'valueOf out cs tn >= n' while also carrying any number of unexpected dust"
+              , "tokens (a Dusk-token attack when the token set is unbounded), and"
+              , "lovelace-only checks silently depend on the min-UTxO requirement, which is a"
+              , "protocol parameter that changes over time. Compare whole values, or bound"
+              , "the token set explicitly."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- passes even if the output is stuffed with arbitrary extra tokens"
+              , "paidOut out = valueOf (txOutValue out) cs tn == amount"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- compare the full expected value: nothing unexpected can ride along"
+              , "paidOut out = txOutValue out == expectedValue"
+              ]
+          , docsAnchor = "value-handling"
+          }
+      )
+    , ( Id "PLU-STAN-10"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "'unsafeFromBuiltinData' checks only the shape of the encoding, not the"
+              , "ledger's invariants — e.g. that a credential hash is exactly 28 bytes. A"
+              , "user-supplied Address or PubKeyHash can be structurally valid yet impossible"
+              , "for the ledger to ever produce in a real output, so an equality check"
+              , "against it becomes unsatisfiable. In a lending validator this is fatal: the"
+              , "lender supplies a bogus repayment address at loan creation, the borrower can"
+              , "never build a repayment transaction, and their collateral is guaranteed to"
+              , "be liquidated."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- repayAddr came from attacker-supplied data; if its hash is not"
+              , "-- 28 bytes, no real output can ever satisfy this equality"
+              , "LoanDatum{repayAddr} = unsafeFromBuiltinData datum"
+              , "repaid out = txOutAddress out == repayAddr"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- validate ledger invariants (hash lengths, well-formed staking part)"
+              , "-- on the raw BuiltinData before trusting the address in a check"
+              , "repaid out ="
+              , "  isBuiltinAddress repayAddrData  -- e.g. checks 28-byte credential hash"
+              , "    && txOutAddress out == repayAddr"
+              ]
+          , docsAnchor = "data-handling--deserialization"
+          }
+      )
+    , ( Id "PLU-STAN-11"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "'currencySymbolValueOf' sums every token amount under a currency symbol"
+              , "without requiring the entries to have a uniform sign. A burn-only check like"
+              , "'currencySymbolValueOf minted ownCS < 0' is satisfied by a transaction that"
+              , "burns 2 TokenA while minting 1 TokenB under the same symbol — the sum is"
+              , "negative, yet the attacker just minted an unauthorized token through your"
+              , "Burn redeemer."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- passes with txInfoMint = [(TokenA, -2), (TokenB, 1)]: TokenB is minted!"
+              , "Burn -> currencySymbolValueOf (txInfoMint info) ownCS < 0"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- every amount under our symbol must be strictly negative"
+              , "Burn -> allBurns (tokenAmounts (txInfoMint info) ownCS)"
+              , "  where"
+              , "    allBurns []       = True"
+              , "    allBurns (n : ns) = n < 0 && allBurns ns"
+              ]
+          , docsAnchor = "value-handling"
+          }
+      )
+    , ( Id "PLU-STAN-12"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "A transaction's validity range is chosen by whoever builds the transaction,"
+              , "and by default it is unbounded on both sides. Interval helpers like 'from',"
+              , "'to', 'always', or 'contains' make it easy to write a time check that an"
+              , "unbounded range satisfies — e.g. \"not before the deadline\" logic that a"
+              , "range of [now, +inf) passes even when submitted long before the deadline,"
+              , "letting vesting or auction funds be claimed early. Always require the"
+              , "relevant bound of 'txInfoValidRange' to be 'Finite' before comparing it."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- an open-ended range [now, +inf) extends past the deadline, so this"
+              , "-- passes even for a transaction submitted before the deadline"
+              , "deadlinePassed = not (to deadline `contains` txInfoValidRange info)"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- require a Finite lower bound and compare it against the deadline"
+              , "deadlinePassed = case ivFrom (txInfoValidRange info) of"
+              , "  LowerBound (Finite t) _ -> t > deadline"
+              , "  _                       -> traceError \"unbounded validity range\""
+              ]
+          , docsAnchor = "validity-interval--posix-time-misuse"
+          }
+      )
+    , ( Id "PLU-STAN-13"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "A validator that pins down an output's address, value, and datum but never"
+              , "constrains 'txOutReferenceScript' lets the transaction builder attach an"
+              , "arbitrary reference script to that output. That silently raises the"
+              , "output's min-ADA requirement and plants attacker-chosen code on a UTxO your"
+              , "protocol treats as trusted — off-chain code or downstream validators that"
+              , "resolve reference scripts from your outputs can be steered to the"
+              , "attacker's script. Assert the expected policy (usually 'Nothing')"
+              , "explicitly, or document why it is irrelevant."
+              ]
+          , docsBadExample = Text.unlines
+              [ "okOutput out ="
+              , "  txOutAddress out == vaultAddr"
+              , "    && txOutValue out == expectedValue"
+              , "    && txOutDatum out == expectedDatum"
+              , "    -- txOutReferenceScript is never constrained"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "okOutput out ="
+              , "  txOutAddress out == vaultAddr"
+              , "    && txOutValue out == expectedValue"
+              , "    && txOutDatum out == expectedDatum"
+              , "    && txOutReferenceScript out == Nothing"
+              ]
+          , docsAnchor = ""
+          }
+      )
+    , ( Id "PLU-STAN-14"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "Checking several fields of an output while matching only the payment part"
+              , "of its address leaves the staking credential attacker-chosen. The output"
+              , "still \"pays to the script\" as far as the payment credential is concerned,"
+              , "but the staking rewards earned by all value sitting at that output flow to"
+              , "the attacker's stake key — staking value theft against the funds your"
+              , "contract is supposed to protect. Compare the full 'Address', or assert the"
+              , "staking credential explicitly."
+              ]
+          , docsBadExample = Text.unlines
+              [ "okOutput out ="
+              , "  txOutValue out == expectedValue"
+              , "    && addressCredential (txOutAddress out) == vaultCredential"
+              , "    -- the staking part of the address is unconstrained"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "okOutput out ="
+              , "  txOutValue out == expectedValue"
+              , "    && txOutAddress out == vaultAddress  -- payment AND staking parts"
+              ]
+          , docsAnchor = ""
+          }
+      )
+    , ( Id "PLU-STAN-15"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "If a validator checks an output's address and datum but never constrains"
+              , "'txOutValue', the transaction builder decides how much value that output"
+              , "carries. The classic exploit is a continuing-output check: the attacker"
+              , "re-locks the vault with a dust amount and the expected datum, satisfies the"
+              , "validator, and walks away with the difference. Every security-relevant"
+              , "output needs an explicit value constraint — at minimum the required assets"
+              , "and amounts."
+              ]
+          , docsBadExample = Text.unlines
+              [ "okOutput out ="
+              , "  txOutAddress out == vaultAddr"
+              , "    && txOutDatum out == expectedDatum"
+              , "    -- value is unconstrained: a dust output satisfies this"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "okOutput out ="
+              , "  txOutAddress out == vaultAddr"
+              , "    && txOutDatum out == expectedDatum"
+              , "    && txOutValue out == expectedValue"
+              ]
+          , docsAnchor = ""
+          }
+      )
+    , ( Id "PLU-STAN-16"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "On-chain arithmetic is integer-only, and 'divide' truncates. Dividing before"
+              , "multiplying throws the remainder away before it can be scaled back up, so"
+              , "results are systematically too small — and an attacker picks the amounts."
+              , "A fee computed as '(amount `divide` 10000) * rate' is exactly 0 for any"
+              , "amount below 10000, letting users transact fee-free by splitting into small"
+              , "amounts. Multiplying first keeps full precision until the single final"
+              , "division."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- amount = 9999 gives fee 0 for any rate: rounding happens too early"
+              , "fee amount rate = (amount `divide` 10000) * rate"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- multiply first: rounding happens once, at the very end"
+              , "fee amount rate = (amount * rate) `divide` 10000"
+              ]
+          , docsAnchor = "integers"
+          }
+      )
+    , ( Id "PLU-STAN-17"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "Redeemers often carry indices into the inputs or outputs list to spare the"
+              , "script an on-chain search. If the validator does not enforce that those"
+              , "indices are pairwise distinct, an attacker submits the same index twice and"
+              , "one honest element is validated multiple times — the double-satisfaction"
+              , "attack, e.g. a single payment output counted against two separate"
+              , "obligations. Enforce uniqueness (strictly increasing indices, or a bitmask)"
+              , "or select elements by stable identifiers such as 'TxOutRef' instead."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- redeemer [2, 2] makes one output satisfy two claims"
+              , "checkClaims is = go is"
+              , "  where"
+              , "    go []         = True"
+              , "    go (i : rest) = paysClaim (txInfoOutputs info !! i) && go rest"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "-- strictly increasing indices are necessarily unique"
+              , "checkClaims is = go (negate 1) is"
+              , "  where"
+              , "    go _prev []         = True"
+              , "    go prev  (i : rest) ="
+              , "      i > prev && paysClaim (txInfoOutputs info !! i) && go i rest"
+              ]
+          , docsAnchor = ""
+          }
+      )
+    , ( Id "PLU-STAN-18"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "Plinth compiles the lazy '(&&)' with delay/force wrappers so that the right"
+              , "operand is only evaluated when the left one is 'True'. In the predicate of"
+              , "a branch whose failure case immediately errors, that laziness buys nothing"
+              , "— the transaction is rejected either way — but the extra delay/force nodes"
+              , "are executed and billed on every validation. A strict combinator built on"
+              , "'ifThenElse' avoids the overhead. Keep '(&&)' only when the right-hand side"
+              , "deliberately throws (e.g. 'traceError') and short-circuiting matters."
+              ]
+          , docsBadExample = Text.unlines
+              [ "-- lazy (&&) adds delay/force overhead; the failure branch errors anyway"
+              , "if signedByOwner && deadlineOk then () else traceError \"bad tx\""
+              ]
+          , docsGoodExample = Text.unlines
+              [ "{-# INLINE builtinAnd #-}"
+              , "builtinAnd :: Bool -> Bool -> Bool"
+              , "builtinAnd b1 b2 = BI.ifThenElse b1 b2 False"
+              , ""
+              , "if signedByOwner `builtinAnd` deadlineOk then () else traceError \"bad tx\""
+              ]
+          , docsAnchor = ""
+          }
+      )
+    , ( Id "PLU-STAN-19"
+      , InspectionDocs
+          { docsWhyItMatters = Text.unlines
+              [ "An output re-locked at a script address carries the contract's state in its"
+              , "datum. If the validator checks address and value but leaves the datum"
+              , "unconstrained, the transaction builder writes whatever state they like into"
+              , "the continuing output — changing the recorded owner, price, or debt — or"
+              , "attaches a malformed datum the validator can never parse, permanently"
+              , "bricking the UTxO and the funds it holds. Pin down the datum shape and its"
+              , "security-critical fields for every continuing output."
+              ]
+          , docsBadExample = Text.unlines
+              [ "okOutput out ="
+              , "  txOutAddress out == vaultAddr"
+              , "    && txOutValue out == expectedValue"
+              , "    -- datum unconstrained: the attacker rewrites the vault state"
+              ]
+          , docsGoodExample = Text.unlines
+              [ "okOutput out ="
+              , "  txOutAddress out == vaultAddr"
+              , "    && txOutValue out == expectedValue"
+              , "    && txOutDatum out == OutputDatum (Datum (toBuiltinData newState))"
+              ]
+          , docsAnchor = ""
+          }
+      )
+    ]

--- a/src/Stan/Plinth/Payload.hs
+++ b/src/Stan/Plinth/Payload.hs
@@ -12,6 +12,7 @@ module Stan.Plinth.Payload
     , mkAnalyzePayload
     , mkCapabilitiesPayload
     , uniquifyFingerprints
+    , dedupeObservations
     ) where
 
 import Data.Aeson.Micro (Value, object, (.=))
@@ -51,27 +52,15 @@ mkAnalyzePayload targetModule inspections observations = object
 in span order, so dismissing one of two identical findings never
 dismisses both.
 
-Observations are sorted by a total order (file, full span, inspection
-id) first, so both the suffix assignment and the payload's observation
-order are canonical regardless of upstream traversal order.
+Observations are first deduplicated (see 'dedupeObservations') and
+sorted by a total order (file, full span, inspection id), so both the
+suffix assignment and the payload's observation order are canonical
+regardless of upstream traversal order.
 -}
 uniquifyFingerprints :: [Observation] -> [(Observation, Text)]
 uniquifyFingerprints observations =
-    reverse $ fst $ foldl' step ([], HM.empty) sorted
+    reverse $ fst $ foldl' step ([], HM.empty) (dedupeObservations observations)
   where
-    sorted :: [Observation]
-    sorted = sortOn spanKey observations
-
-    spanKey :: Observation -> (FilePath, Int, Int, Int, Int, Text)
-    spanKey o =
-        ( observationFile o
-        , srcSpanStartLine (observationSrcSpan o)
-        , srcSpanStartCol (observationSrcSpan o)
-        , srcSpanEndLine (observationSrcSpan o)
-        , srcSpanEndCol (observationSrcSpan o)
-        , unId (observationInspectionId o)
-        )
-
     step
         :: ([(Observation, Text)], HashMap Text Int)
         -> Observation
@@ -81,6 +70,49 @@ uniquifyFingerprints observations =
             n = HM.lookupDefault 0 base seen + 1
             fp = if n == 1 then base else base <> "#" <> show n
         in ((o, fp) : acc, HM.insert base n seen)
+
+{- | Sort observations into the canonical @(file, span, inspection id)@
+order, then collapse observations that report the exact same rule for
+the exact same source span down to one.
+
+Several upstream inspections walk the HIE AST in a way that visits the
+same syntactic construct more than once (e.g. once while matching the
+whole rewrite pattern and again while re-examining one of its
+sub-terms, or once per overlapping traversal branch that both happen
+to land on the same node) and end up calling 'mkObservation' several
+times for an identical @(inspectionId, file, span)@ triple. That is
+one finding reported redundantly, not several distinct ones, so only
+the first occurrence — the one that sorts first in the canonical order
+— is kept.
+
+This must run /before/ fingerprint-suffix assignment in
+'uniquifyFingerprints': two observations that flag the same text but
+sit at genuinely different locations have different spans, so
+'dedupeObservations' leaves both, and they still get distinct @#2@,
+@#3@… suffixes downstream.
+-}
+dedupeObservations :: [Observation] -> [Observation]
+dedupeObservations = dedupAdjacent . sortOn spanKey
+  where
+    dedupAdjacent :: [Observation] -> [Observation]
+    dedupAdjacent [] = []
+    dedupAdjacent (o : os) = o : go (spanKey o) os
+      where
+        go :: (FilePath, Int, Int, Int, Int, Text) -> [Observation] -> [Observation]
+        go _ [] = []
+        go prevKey (x : xs)
+            | spanKey x == prevKey = go prevKey xs
+            | otherwise = x : go (spanKey x) xs
+
+spanKey :: Observation -> (FilePath, Int, Int, Int, Int, Text)
+spanKey o =
+    ( observationFile o
+    , srcSpanStartLine (observationSrcSpan o)
+    , srcSpanStartCol (observationSrcSpan o)
+    , srcSpanEndLine (observationSrcSpan o)
+    , srcSpanEndCol (observationSrcSpan o)
+    , unId (observationInspectionId o)
+    )
 
 inspectionToJson :: Inspection -> Value
 inspectionToJson Inspection{..} = object $

--- a/src/Stan/Plinth/Payload.hs
+++ b/src/Stan/Plinth/Payload.hs
@@ -16,6 +16,7 @@ module Stan.Plinth.Payload
 
 import Data.Aeson.Micro (Value, object, (.=))
 
+import Stan.Core.Id (unId)
 import Stan.Core.ModuleName (ModuleName)
 import Stan.Ghc.Compat (srcSpanEndCol, srcSpanEndLine, srcSpanStartCol, srcSpanStartLine)
 import Stan.Inspection (Inspection (..))
@@ -49,6 +50,10 @@ mkAnalyzePayload targetModule inspections observations = object
 (same rule, same module, same flagged text) get @#2@, @#3@… suffixes
 in span order, so dismissing one of two identical findings never
 dismisses both.
+
+Observations are sorted by a total order (file, full span, inspection
+id) first, so both the suffix assignment and the payload's observation
+order are canonical regardless of upstream traversal order.
 -}
 uniquifyFingerprints :: [Observation] -> [(Observation, Text)]
 uniquifyFingerprints observations =
@@ -57,11 +62,14 @@ uniquifyFingerprints observations =
     sorted :: [Observation]
     sorted = sortOn spanKey observations
 
-    spanKey :: Observation -> (FilePath, Int, Int)
+    spanKey :: Observation -> (FilePath, Int, Int, Int, Int, Text)
     spanKey o =
         ( observationFile o
         , srcSpanStartLine (observationSrcSpan o)
         , srcSpanStartCol (observationSrcSpan o)
+        , srcSpanEndLine (observationSrcSpan o)
+        , srcSpanEndCol (observationSrcSpan o)
+        , unId (observationInspectionId o)
         )
 
     step

--- a/src/Stan/Plinth/Payload.hs
+++ b/src/Stan/Plinth/Payload.hs
@@ -1,0 +1,107 @@
+{- |
+Copyright: (c) 2026 IOHK
+SPDX-License-Identifier: MPL-2.0
+
+Assembly of the machine-readable (schema v2) payloads emitted by the
+@plustan@ CLI for the VS Code extension. Kept in the library so the
+JSON shape is golden-testable.
+-}
+
+module Stan.Plinth.Payload
+    ( analyzeSchemaVersion
+    , mkAnalyzePayload
+    , mkCapabilitiesPayload
+    , uniquifyFingerprints
+    ) where
+
+import Data.Aeson.Micro (Value, object, (.=))
+
+import Stan.Core.ModuleName (ModuleName)
+import Stan.Ghc.Compat (srcSpanEndCol, srcSpanEndLine, srcSpanStartCol, srcSpanStartLine)
+import Stan.Inspection (Inspection (..))
+import Stan.Observation (Observation (..), observationFingerprint)
+import Stan.Plinth.Docs (InspectionDocs (..), lookupDocs)
+
+import qualified Data.HashMap.Strict as HM
+
+
+-- | Version of the JSON contract between the CLI and the extension.
+analyzeSchemaVersion :: Int
+analyzeSchemaVersion = 2
+
+mkCapabilitiesPayload :: Text -> Value
+mkCapabilitiesPayload ghcVersion = object
+    [ "schemaVersion" .= analyzeSchemaVersion
+    , "ghcVersion" .= ghcVersion
+    , "features" .= (["list-onchain", "analyze", "fingerprints", "inspection-docs"] :: [Text])
+    ]
+
+mkAnalyzePayload :: Maybe ModuleName -> [Inspection] -> [Observation] -> Value
+mkAnalyzePayload targetModule inspections observations = object
+    [ "version" .= analyzeSchemaVersion
+    , "runScope" .= maybe ("all" :: Text) (const "module") targetModule
+    , "targetModule" .= targetModule
+    , "inspections" .= map inspectionToJson inspections
+    , "observations" .= map observationToJson (uniquifyFingerprints observations)
+    ]
+
+{- | Pair each observation with a run-unique fingerprint: duplicates
+(same rule, same module, same flagged text) get @#2@, @#3@… suffixes
+in span order, so dismissing one of two identical findings never
+dismisses both.
+-}
+uniquifyFingerprints :: [Observation] -> [(Observation, Text)]
+uniquifyFingerprints observations =
+    reverse $ fst $ foldl' step ([], HM.empty) sorted
+  where
+    sorted :: [Observation]
+    sorted = sortOn spanKey observations
+
+    spanKey :: Observation -> (FilePath, Int, Int)
+    spanKey o =
+        ( observationFile o
+        , srcSpanStartLine (observationSrcSpan o)
+        , srcSpanStartCol (observationSrcSpan o)
+        )
+
+    step
+        :: ([(Observation, Text)], HashMap Text Int)
+        -> Observation
+        -> ([(Observation, Text)], HashMap Text Int)
+    step (acc, seen) o =
+        let base = observationFingerprint o
+            n = HM.lookupDefault 0 base seen + 1
+            fp = if n == 1 then base else base <> "#" <> show n
+        in ((o, fp) : acc, HM.insert base n seen)
+
+inspectionToJson :: Inspection -> Value
+inspectionToJson Inspection{..} = object $
+    [ "id" .= inspectionId
+    , "name" .= inspectionName
+    , "description" .= inspectionDescription
+    , "solution" .= inspectionSolution
+    , "category" .= toList inspectionCategory
+    , "severity" .= inspectionSeverity
+    ] <> docsPairs
+  where
+    docsPairs = case lookupDocs inspectionId of
+        Nothing -> []
+        Just InspectionDocs{..} ->
+            [ "whyItMatters" .= docsWhyItMatters
+            , "badExample" .= docsBadExample
+            , "goodExample" .= docsGoodExample
+            , "docsAnchor" .= docsAnchor
+            ]
+
+observationToJson :: (Observation, Text) -> Value
+observationToJson (Observation{..}, fingerprint) = object
+    [ "id" .= observationId
+    , "inspectionId" .= observationInspectionId
+    , "fingerprint" .= fingerprint
+    , "startLine" .= srcSpanStartLine observationSrcSpan
+    , "startCol" .= srcSpanStartCol observationSrcSpan
+    , "endLine" .= srcSpanEndLine observationSrcSpan
+    , "endCol" .= srcSpanEndCol observationSrcSpan
+    , "file" .= toText observationFile
+    , "moduleName" .= observationModuleName
+    ]

--- a/stan.cabal
+++ b/stan.cabal
@@ -134,6 +134,7 @@ library
                            Stan.Pattern.Ast
                            Stan.Pattern.Edsl
                            Stan.Pattern.Type
+                         Stan.Plinth.Docs
                          Stan.Report
                            Stan.Report.Css
                            Stan.Report.Html
@@ -258,6 +259,7 @@ test-suite stan-test
                        Test.Stan.Gen
                        Test.Stan.Number
                        Test.Stan.Observation
+                       Test.Stan.Plinth
                        Test.Stan.Toml
 
   build-depends:       stan

--- a/stan.cabal
+++ b/stan.cabal
@@ -135,6 +135,7 @@ library
                            Stan.Pattern.Edsl
                            Stan.Pattern.Type
                          Stan.Plinth.Docs
+                         Stan.Plinth.Payload
                          Stan.Report
                            Stan.Report.Css
                            Stan.Report.Html
@@ -271,6 +272,7 @@ test-suite stan-test
                      , hedgehog >= 1.0 && < 1.6
                      , hspec >= 2.7 && < 2.12
                      , hspec-hedgehog >= 0.0.1.2
+                     , microaeson ^>= 0.1.0.0
                      , optparse-applicative
                      , process
                      , text

--- a/stan.cabal
+++ b/stan.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                stan
-version:             0.2.4.3
+version:             0.2.5.0
 synopsis:            Haskell STatic ANalyser
 description:
     Stan is a Haskell __ST__atic __AN__alysis CLI tool.

--- a/stan.cabal
+++ b/stan.cabal
@@ -261,6 +261,7 @@ test-suite stan-test
                        Test.Stan.Toml
 
   build-depends:       stan
+                     , bytestring
                      , containers
                      , directory
                      , filepath

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -14,6 +14,7 @@ import Test.Stan.Cli (cliSpec)
 import Test.Stan.Config (configSpec)
 import Test.Stan.Number (linesOfCodeSpec, modulesNumSpec)
 import Test.Stan.Observation (observationSpec)
+import Test.Stan.Plinth (plinthSpec)
 import Test.Stan.Toml (tomlSpec)
 
 import Control.Exception (try)
@@ -38,6 +39,7 @@ main = do
                 tomlSpec
                 configSpec
                 observationSpec
+                plinthSpec
                 analysisSpec testHies
 
 isTargetFile :: HieFile -> Bool

--- a/test/Test/Stan/Observation.hs
+++ b/test/Test/Stan/Observation.hs
@@ -3,18 +3,39 @@ module Test.Stan.Observation
     ) where
 
 import Stan.Ghc.Compat (mkRealSrcLoc, mkRealSrcSpan)
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldNotBe)
 
 import Stan.Core.Id (Id (..))
 import Stan.Inspection (inspectionId)
 import Stan.Inspection.Partial (stan0001)
-import Stan.Observation (Observation, mkObservationId)
+import Stan.Observation (Observation (..), mkObservationId, observationFingerprint,
+                         observationSpanText)
+
+import qualified Data.ByteString.Char8 as BS8
 
 
 observationSpec :: Spec
-observationSpec = describe "Observation" $
+observationSpec = describe "Observation" $ do
     it "calculates Observation Id properly" $
         testObservationId `shouldBe` Id "OBS-STAN-0001-bbjjJQ-10:42"
+
+    describe "observationSpanText" $ do
+        -- line 2 is "bad expr here"; cols 5–14 (GHC end col is exclusive)
+        -- select the 9 characters "expr here"
+        it "extracts a single-line span, column-trimmed" $
+            observationSpanText (mkObs 2 5 14 sampleContent)
+                `shouldBe` "expr here"
+        it "extracts a multi-line span" $
+            observationSpanText (mkObs2 2 5 3 6 sampleContent)
+                `shouldBe` "expr here\ny = 2"
+
+    describe "observationFingerprint" $ do
+        it "is stable when the same flagged text moves to another line" $
+            observationFingerprint (mkObs 2 5 14 sampleContent)
+                `shouldBe` observationFingerprint (mkObs 3 5 14 shiftedContent)
+        it "changes when the flagged text changes" $
+            observationFingerprint (mkObs 2 5 14 sampleContent)
+                `shouldNotBe` observationFingerprint (mkObs 2 5 14 editedContent)
   where
     testObservationId :: Id Observation
     testObservationId = mkObservationId
@@ -23,3 +44,26 @@ observationSpec = describe "Observation" $
         $ mkRealSrcSpan
             (mkRealSrcLoc "src/Test/Module/Name.hs" 10 42)
             (mkRealSrcLoc "src/Test/Module/Name.hs" 10 42)
+
+    -- line 1: "x = 1", line 2: "bad expr here", line 3: "y = 2"
+    sampleContent, shiftedContent, editedContent :: ByteString
+    sampleContent  = BS8.pack "x = 1\nbad expr here\ny = 2\n"
+    -- same flagged text, one line lower (a comment was added above)
+    shiftedContent = BS8.pack "-- c\nx = 1\nbad expr here\ny = 2\n"
+    -- the flagged text itself changed
+    editedContent  = BS8.pack "x = 1\nbad EXPR here\ny = 2\n"
+
+    mkObs :: Int -> Int -> Int -> ByteString -> Observation
+    mkObs line startC endC = mkObs2 line startC line endC
+
+    mkObs2 :: Int -> Int -> Int -> Int -> ByteString -> Observation
+    mkObs2 startL startC endL endC content = Observation
+        { observationId = Id "test-obs"
+        , observationInspectionId = inspectionId stan0001
+        , observationSrcSpan = mkRealSrcSpan
+            (mkRealSrcLoc "src/T.hs" startL startC)
+            (mkRealSrcLoc "src/T.hs" endL endC)
+        , observationFile = "src/T.hs"
+        , observationModuleName = "Test.Module.Name"
+        , observationFileContent = content
+        }

--- a/test/Test/Stan/Observation.hs
+++ b/test/Test/Stan/Observation.hs
@@ -28,6 +28,12 @@ observationSpec = describe "Observation" $ do
         it "extracts a multi-line span" $
             observationSpanText (mkObs2 2 5 3 6 sampleContent)
                 `shouldBe` "expr here\ny = 2"
+        it "trims a single-line span ending mid-line (exclusive end col)" $
+            observationSpanText (mkObs 2 5 9 sampleContent)
+                `shouldBe` "expr"
+        it "trims a multi-line span ending mid-line" $
+            observationSpanText (mkObs2 2 5 3 2 sampleContent)
+                `shouldBe` "expr here\ny"
 
     describe "observationFingerprint" $ do
         it "is stable when the same flagged text moves to another line" $

--- a/test/Test/Stan/Plinth.hs
+++ b/test/Test/Stan/Plinth.hs
@@ -1,0 +1,27 @@
+module Test.Stan.Plinth
+    ( plinthSpec
+    ) where
+
+import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, shouldSatisfy)
+
+import Stan.Core.Id (Id (..))
+import Stan.Inspection.All (inspectionsMap)
+import Stan.Plinth.Docs (InspectionDocs (..), lookupDocs)
+
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as Text
+
+
+plinthSpec :: Spec
+plinthSpec = describe "Stan.Plinth.Docs" $ do
+    it "covers every PLU-STAN inspection" $ do
+        let plinthIds = filter (Text.isPrefixOf "PLU-STAN" . unId) (HM.keys inspectionsMap)
+        let missing = filter (isNothing . lookupDocs) plinthIds
+        missing `shouldBe` []
+    it "has non-empty teaching content everywhere" $
+        case lookupDocs (Id "PLU-STAN-04") of
+            Nothing -> expectationFailure "no docs for PLU-STAN-04"
+            Just InspectionDocs{..} -> do
+                docsWhyItMatters `shouldSatisfy` (not . Text.null)
+                docsBadExample `shouldSatisfy` (not . Text.null)
+                docsGoodExample `shouldSatisfy` (not . Text.null)

--- a/test/Test/Stan/Plinth.hs
+++ b/test/Test/Stan/Plinth.hs
@@ -10,8 +10,9 @@ import Stan.Core.Id (Id (..))
 import Stan.Ghc.Compat (mkRealSrcLoc, mkRealSrcSpan)
 import Stan.Inspection (inspectionId)
 import Stan.Inspection.All (inspectionsMap)
+import Stan.Inspection.AntiPattern (plustan04)
 import Stan.Inspection.Partial (stan0001)
-import Stan.Observation (Observation (..))
+import Stan.Observation (Observation (..), observationFingerprint)
 import Stan.Plinth.Docs (InspectionDocs (..), lookupDocs, plinthDocsMap)
 import Stan.Plinth.Payload (mkAnalyzePayload, mkCapabilitiesPayload, uniquifyFingerprints)
 
@@ -58,12 +59,23 @@ payloadSpec = describe "Stan.Plinth.Payload" $ do
         let o2 = mkPayloadObs 2 content
         let fps = map snd (uniquifyFingerprints [o2, o1])   -- input deliberately unordered
         case fps of
-            [fp1, fp2] -> fp2 `shouldBe` (fp1 <> "#2")
+            [fp1, fp2] -> do
+                fp1 `shouldBe` observationFingerprint o1
+                fp2 `shouldBe` (fp1 <> "#2")
             _ -> expectationFailure "expected exactly two fingerprints"
     it "analyze payload is version 2 with top-level observations" $ do
         let payloadText = LBS8.unpack (encode (mkAnalyzePayload Nothing [] []))
         payloadText `shouldSatisfy` isInfixOf "\"version\":2"
         payloadText `shouldSatisfy` isInfixOf "\"observations\":[]"
+    it "golden: non-empty analyze payload encoding is byte-stable" $ do
+        let content = BS8.pack "f x\nf x\n"
+        let obs = mkPayloadObs 1 content
+        let payloadText = LBS8.unpack (encode
+                (mkAnalyzePayload (Just "Test.Module.Name") [stan0001] [obs]))
+        payloadText `shouldBe` goldenAnalyzePayload
+    it "enriches PLU-STAN inspections with teaching docs fields" $ do
+        let payloadText = LBS8.unpack (encode (mkAnalyzePayload Nothing [plustan04] []))
+        payloadText `shouldSatisfy` isInfixOf "\"whyItMatters\":"
   where
     mkPayloadObs :: Int -> ByteString -> Observation
     mkPayloadObs line content = Observation
@@ -76,3 +88,16 @@ payloadSpec = describe "Stan.Plinth.Payload" $ do
         , observationModuleName = "Test.Module.Name"
         , observationFileContent = content
         }
+
+    -- Derived from a reference run of microaeson's canonical (alphabetically
+    -- keyed) encoding; pins the schema-v2 wire contract byte for byte.
+    goldenAnalyzePayload :: String
+    goldenAnalyzePayload =
+        "{\"inspections\":[{\"category\":[\"Partial\",\"List\"],\"description\":\"Usage of partial \
+        \function 'head' for lists\",\"id\":\"STAN-0001\",\"name\":\"Partial: base/head\",\"severit\
+        \y\":\"Warning\",\"solution\":[\"Replace list with 'NonEmpty' from 'Data.List.NonEmpty'\",\
+        \\"Use explicit pattern-matching over lists\"]}],\"observations\":[{\"endCol\":4,\"endLine\
+        \\":1,\"file\":\"src/T.hs\",\"fingerprint\":\"FPR-STAN-0001-bbjjJQ-NmTLVWB5C9\",\"id\":\"ob\
+        \s-1\",\"inspectionId\":\"STAN-0001\",\"moduleName\":\"Test.Module.Name\",\"startCol\":1,\"\
+        \startLine\":1}],\"runScope\":\"module\",\"targetModule\":\"Test.Module.Name\",\"version\":\
+        \2}"

--- a/test/Test/Stan/Plinth.hs
+++ b/test/Test/Stan/Plinth.hs
@@ -63,6 +63,17 @@ payloadSpec = describe "Stan.Plinth.Payload" $ do
                 fp1 `shouldBe` observationFingerprint o1
                 fp2 `shouldBe` (fp1 <> "#2")
             _ -> expectationFailure "expected exactly two fingerprints"
+    it "dedupes observations that report the same rule at the exact same span" $ do
+        let content = BS8.pack "f x\n"
+        let o1 = mkPayloadObs 1 content
+        let o2 = o1 { observationId = Id "obs-1-again" }
+        let o3 = o1 { observationId = Id "obs-1-yet-again" }
+        let pairs = uniquifyFingerprints [o1, o2, o3]
+        case pairs of
+            [(o, fp)] -> do
+                o `shouldBe` o1
+                fp `shouldBe` observationFingerprint o1
+            _ -> expectationFailure ("expected exactly one deduped pair, got " <> show (length pairs))
     it "analyze payload is version 2 with top-level observations" $ do
         let payloadText = LBS8.unpack (encode (mkAnalyzePayload Nothing [] []))
         payloadText `shouldSatisfy` isInfixOf "\"version\":2"

--- a/test/Test/Stan/Plinth.hs
+++ b/test/Test/Stan/Plinth.hs
@@ -2,18 +2,30 @@ module Test.Stan.Plinth
     ( plinthSpec
     ) where
 
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Data.Aeson.Micro (encode, object, (.=))
+import Data.List (isInfixOf)
+import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, shouldSatisfy)
 
 import Stan.Core.Id (Id (..))
+import Stan.Ghc.Compat (mkRealSrcLoc, mkRealSrcSpan)
+import Stan.Inspection (inspectionId)
 import Stan.Inspection.All (inspectionsMap)
+import Stan.Inspection.Partial (stan0001)
+import Stan.Observation (Observation (..))
 import Stan.Plinth.Docs (InspectionDocs (..), lookupDocs, plinthDocsMap)
+import Stan.Plinth.Payload (mkAnalyzePayload, mkCapabilitiesPayload, uniquifyFingerprints)
 
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy.Char8 as LBS8
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as Text
 
 
 plinthSpec :: Spec
-plinthSpec = describe "Stan.Plinth.Docs" $ do
+plinthSpec = docsSpec >> payloadSpec
+
+docsSpec :: Spec
+docsSpec = describe "Stan.Plinth.Docs" $ do
     it "covers every PLU-STAN inspection" $ do
         let plinthIds = filter (Text.isPrefixOf "PLU-STAN" . unId) (HM.keys inspectionsMap)
         let missing = filter (isNothing . lookupDocs) plinthIds
@@ -31,3 +43,36 @@ plinthSpec = describe "Stan.Plinth.Docs" $ do
                     || Text.null docsGoodExample
                 ]
         offenders `shouldBe` []
+
+payloadSpec :: Spec
+payloadSpec = describe "Stan.Plinth.Payload" $ do
+    it "capabilities carries schemaVersion 2" $
+        mkCapabilitiesPayload "9.6.6" `shouldBe` object
+            [ "schemaVersion" .= (2 :: Int)
+            , "ghcVersion" .= ("9.6.6" :: Text)
+            , "features" .= (["list-onchain", "analyze", "fingerprints", "inspection-docs"] :: [Text])
+            ]
+    it "suffixes duplicate fingerprints in span order" $ do
+        let content = BS8.pack "f x\nf x\n"      -- identical flagged text on 2 lines
+        let o1 = mkPayloadObs 1 content
+        let o2 = mkPayloadObs 2 content
+        let fps = map snd (uniquifyFingerprints [o2, o1])   -- input deliberately unordered
+        case fps of
+            [fp1, fp2] -> fp2 `shouldBe` (fp1 <> "#2")
+            _ -> expectationFailure "expected exactly two fingerprints"
+    it "analyze payload is version 2 with top-level observations" $ do
+        let payloadText = LBS8.unpack (encode (mkAnalyzePayload Nothing [] []))
+        payloadText `shouldSatisfy` isInfixOf "\"version\":2"
+        payloadText `shouldSatisfy` isInfixOf "\"observations\":[]"
+  where
+    mkPayloadObs :: Int -> ByteString -> Observation
+    mkPayloadObs line content = Observation
+        { observationId = Id ("obs-" <> show line)
+        , observationInspectionId = inspectionId stan0001
+        , observationSrcSpan = mkRealSrcSpan
+            (mkRealSrcLoc "src/T.hs" line 1)
+            (mkRealSrcLoc "src/T.hs" line 4)
+        , observationFile = "src/T.hs"
+        , observationModuleName = "Test.Module.Name"
+        , observationFileContent = content
+        }

--- a/test/Test/Stan/Plinth.hs
+++ b/test/Test/Stan/Plinth.hs
@@ -2,11 +2,11 @@ module Test.Stan.Plinth
     ( plinthSpec
     ) where
 
-import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, shouldSatisfy)
+import Test.Hspec (Spec, describe, it, shouldBe)
 
 import Stan.Core.Id (Id (..))
 import Stan.Inspection.All (inspectionsMap)
-import Stan.Plinth.Docs (InspectionDocs (..), lookupDocs)
+import Stan.Plinth.Docs (InspectionDocs (..), lookupDocs, plinthDocsMap)
 
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as Text
@@ -18,10 +18,16 @@ plinthSpec = describe "Stan.Plinth.Docs" $ do
         let plinthIds = filter (Text.isPrefixOf "PLU-STAN" . unId) (HM.keys inspectionsMap)
         let missing = filter (isNothing . lookupDocs) plinthIds
         missing `shouldBe` []
-    it "has non-empty teaching content everywhere" $
-        case lookupDocs (Id "PLU-STAN-04") of
-            Nothing -> expectationFailure "no docs for PLU-STAN-04"
-            Just InspectionDocs{..} -> do
-                docsWhyItMatters `shouldSatisfy` (not . Text.null)
-                docsBadExample `shouldSatisfy` (not . Text.null)
-                docsGoodExample `shouldSatisfy` (not . Text.null)
+    it "has no stale docs for removed or renamed inspections" $ do
+        let stale = filter (\insId -> not (HM.member insId inspectionsMap))
+                (HM.keys plinthDocsMap)
+        stale `shouldBe` []
+    it "has non-empty teaching content everywhere" $ do
+        let offenders =
+                [ unId insId
+                | (insId, InspectionDocs{..}) <- HM.toList plinthDocsMap
+                , Text.null docsWhyItMatters
+                    || Text.null docsBadExample
+                    || Text.null docsGoodExample
+                ]
+        offenders `shouldBe` []

--- a/vscode-plustan/MARKETPLACE.md
+++ b/vscode-plustan/MARKETPLACE.md
@@ -1,55 +1,67 @@
 # Plu-Stan
 
-**Plu-Stan** is a static analysis tool for Cardano smart contracts written in [Plinth](https://github.com/input-output-hk/plutus). This extension surfaces Plu-Stan findings directly in VS Code and Cursor as diagnostics in the Problems panel — no manual CLI invocation required.
+**Plu-Stan** is a static analysis tool for Cardano smart contracts written in [Plinth](https://github.com/input-output-hk/plutus). This extension turns it into a **review cockpit** right inside VS Code and Cursor: catch security and performance anti-patterns before they ship, with a per-rule explanation of *why* each one matters — no manual CLI invocation required.
 
 ## Features
 
+- **Review sessions** — click ▶ **Start Review** to analyze your onchain modules and open a live findings workspace: a tree grouped by severity and rule (or by module), squiggles in the editor, and entries in the Problems panel
+- **Finding Detail panel** — click any finding to see why it matters, a ✗ bad-example / ✓ good-example pair, concrete how-to-fix guidance, and a link to the full rule documentation
+- **Persistent dismissals** — dismiss a finding you've judged not applicable (with an optional note); it's recorded in `.plustan/dismissals.json` so the decision survives restarts and can be committed and shared with your team
+- **Staleness tracking** — editing a file marks its open findings as stale immediately, and saving an onchain module automatically re-runs analysis and reconciles what's fixed, what's new, and what's still open
+- **Status bar at a glance** — live open/fixed counts for the active review session
 - **Onchain module explorer** — tree view listing all modules annotated with `onchain-contract`, auto-discovered from your workspace
-- **Workspace analysis** — run Plu-Stan across your entire project with one click
-- **Per-module analysis** — target a single onchain module from the tree view
-- **VS Code Diagnostics integration** — findings appear in the Problems panel with severity, rule ID, and description
+- **One-shot commands** — `Run Workspace` / `Run Module` for a quick, session-free pass
 - **Works in Cursor** — fully compatible with the Cursor editor
 
 ## Requirements
 
-- The `plustan` binary built from [input-output-hk/plu-stan](https://github.com/input-output-hk/plu-stan)
+- The `plustan` binary built from [input-output-hk/plu-stan](https://github.com/input-output-hk/plu-stan). Extension 0.3.x requires `plustan` >= 0.2.5.0; the extension checks this automatically via a `plustan capabilities` handshake and prompts you to update if there's a mismatch.
 - A Haskell workspace compiled with `.hie`/`.hi` artifacts (Plu-Stan will trigger a build automatically if needed)
-- A GHC the extension ships a prebuilt binary for (currently 9.6.7, 9.8.4, 9.10.3, 9.12.2). The `plustan` binary reads `.hie` files, whose format is locked to the **exact** GHC version that produced them, so the extension auto-downloads the binary matching your project's GHC. If your project uses a different GHC, build `plustan` with that GHC and set `plustan.binaryPath`.
+- A GHC the extension ships a prebuilt binary for. The `plustan` binary reads `.hie` files, whose format is locked to the **exact** GHC version that produced them, so the extension auto-downloads the binary matching your project's GHC. If your project uses a different GHC, build `plustan` with that GHC and set `plustan.binaryPath`.
 
 ## Getting Started
 
-1. Build and install the `plustan` binary:
-   ```bash
-   cabal install exe:stan
-   ```
-2. Open your Plinth project in VS Code
-3. Set `plustan.binaryPath` to the absolute path of the `plustan` executable (via Settings or `settings.json`):
+1. Open your Plinth project in VS Code or Cursor.
+2. Open the **Plu-Stan** panel in the Activity Bar. If no binary is configured, you'll be offered a one-click download matched to your project's GHC (or run `Plu-Stan: Check for Updates` yourself). To point at a binary you built yourself, set `plustan.binaryPath`:
    ```json
    {
      "plustan.binaryPath": "/path/to/plustan"
    }
    ```
-4. Open the **Plu-Stan** panel in the Activity Bar and click **Run Workspace**
+3. In the **Findings** view, click **Start Review** (▶), pick the modules to review (or accept all), and work the findings tree: click through to each issue, read the explanation, fix it or dismiss it.
+4. Click **End Review** when you're done — it stops auto re-runs and logs a fixed/open/dismissed summary.
 
 ## Commands
 
 | Command | Description |
 |---|---|
+| `Plu-Stan: Start Review` | Begin a review session over the whole workspace or chosen modules |
+| `Plu-Stan: End Review` | Stop auto re-runs and summarize the session |
+| `Plu-Stan: Toggle Findings Grouping` | Switch the Findings tree between severity/rule and module grouping |
+| `Plu-Stan: Open Finding` | Jump to a finding's location in the editor |
+| `Plu-Stan: Dismiss Finding` | Mark a finding as not applicable, with an optional note |
+| `Plu-Stan: Restore Dismissed Finding` | Reopen a previously dismissed finding |
+| `Plu-Stan: Run Workspace` | One-shot analysis of the full workspace (disabled during a review session) |
+| `Plu-Stan: Run Module` | One-shot analysis of the selected onchain module (disabled during a review session) |
 | `Plu-Stan: Refresh Onchain Modules` | Re-scan the workspace for onchain modules |
-| `Plu-Stan: Run Workspace` | Analyse the full workspace |
-| `Plu-Stan: Run Module` | Analyse the selected onchain module |
 | `Plu-Stan: Clear Diagnostics` | Clear all Plu-Stan findings from the Problems panel |
 | `Plu-Stan: Show Output` | Open the Plu-Stan output channel |
+| `Plu-Stan: Open Settings` | Jump to Plu-Stan settings |
+| `Plu-Stan: Check for Updates` | Download the `plustan` binary matching your project's GHC |
 
 ## Settings
 
 | Setting | Default | Description |
 |---|---|---|
-| `plustan.binaryPath` | `""` | Absolute path to the `plustan` executable (required) |
+| `plustan.binaryPath` | `""` | Path to the `plustan` executable. Supports a leading `${workspaceFolder}` token. Leave empty to let the extension manage a downloaded binary |
 | `plustan.projectDir` | `""` | Project directory. Defaults to the active workspace folder |
 | `plustan.hieDir` | `".hie"` | Directory containing `.hie`/`.hi` files, relative to `projectDir` |
 | `plustan.extraArgs` | `[]` | Additional CLI arguments appended to `plustan analyze` runs |
 | `plustan.showOutputChannel` | `true` | Automatically show the output channel when running commands |
+
+## `.plustan/dismissals.json`
+
+Every dismissal is recorded in `.plustan/dismissals.json` at your workspace root, with a timestamp and your optional note. Commit it so the whole team sees the same set of accepted findings — and so a future CI check can hold the line on anything left open.
 
 ## Rules
 
@@ -69,7 +81,7 @@ Plu-Stan checks for security and performance issues specific to Plinth on-chain 
 - Validity interval / POSIX time misuse (PLU-STAN-12)
 - Division before multiplication precision loss (PLU-STAN-16)
 
-For full rule documentation see the [plu-stan repository](https://github.com/input-output-hk/plu-stan/blob/main/rules.md).
+Each rule's finding comes with a plain-language explanation, a bad/good example pair, and a fix suggestion right in the Finding Detail panel. For full rule documentation see the [plu-stan repository](https://github.com/input-output-hk/plu-stan/blob/main/RULES.md).
 
 ## License
 

--- a/vscode-plustan/README.md
+++ b/vscode-plustan/README.md
@@ -1,21 +1,27 @@
-# Plu-Stan VS Code/Cursor Extension (MVP)
+# Plu-Stan for VS Code / Cursor
 
-This extension integrates the local `plustan` CLI.
+Security and performance static analysis for Cardano smart contracts written in [Plinth](https://github.com/input-output-hk/plutus), delivered as a review cockpit in the **Plu-Stan** sidebar. It runs the local `plustan` CLI, surfaces findings as an interactive tree with per-rule teaching docs, and tracks them through your edit/fix/dismiss workflow.
 
-It is implemented as a standard VS Code extension, so it can be used in both VS Code and Cursor.
+It is a standard VS Code extension, so it works in both VS Code and Cursor.
 
-## Features
+## Review workflow
 
-- Explorer Tree View for modules annotated with `onchain-contract`.
-- Large action rows at the top of the tree for refresh/run/clear/output actions.
-- Run `plustan` for a selected onchain module.
-- Run `plustan` for the full workspace.
-- Publish findings to VS Code Diagnostics / Problems.
+1. **Start Review** — from the ▶ icon in the Findings view title bar, or `Plu-Stan: Start Review` in the command palette. If the workspace has more than one onchain module, you're prompted to pick which ones to review (all preselected); otherwise it reviews everything.
+2. Plu-Stan analyzes the selected scope and populates the **Findings** tree, grouped by **severity → rule** by default (toggle to grouping by **module** with `Plu-Stan: Toggle Findings Grouping`). Findings also appear as squiggles in the editor and entries in the Problems panel, and a status bar item shows an open/fixed count for the session.
+3. Click a finding to open its location in the editor and populate the **Finding Detail** panel with why it matters, a ✗ bad-example / ✓ good-example pair, how-to-fix guidance, and a link to the full rule documentation (when the backend ships that data for the rule).
+4. **Dismiss** a finding you've judged not applicable — from the tree's inline action or the detail panel. You can attach an optional note. Dismissals persist to `.plustan/dismissals.json` and the finding moves to a collapsed "Dismissed" group. **Restore Dismissed Finding** reopens it.
+5. Editing a file with open findings marks them **stale** (a `~` prefix and history icon) immediately; saving a reviewed onchain module automatically re-runs analysis for that module and reconciles the findings — fixed ones move to a "Fixed this session" group, newly introduced ones appear as open.
+6. **End Review** stops auto re-runs on save and prints a fixed/open/dismissed summary to the Plu-Stan output channel.
+
+## Legacy one-shot commands
+
+`Plu-Stan: Run Workspace` and `Plu-Stan: Run Module` still exist for a quick, session-free pass: they run `plustan` once and publish diagnostics, with no tracking, staleness, or auto re-run. They are **disabled while a review session is active** — use the Findings view, or run `Plu-Stan: End Review` first.
 
 ## Requirements
 
-- `plustan.binaryPath` must be set to an absolute `plustan` executable path.
-- A buildable Haskell workspace with `.hie`/`.hi` artifacts (the CLI will auto-build when needed).
+- A `plustan` binary. Set `plustan.binaryPath`, or run **Plu-Stan: Check for Updates** to download one matching your project's GHC (detected from your `.hie` files) via a `plustan capabilities` handshake.
+- A buildable Haskell workspace producing `.hie`/`.hi` artifacts — the CLI auto-builds when needed.
+- Extension 0.3.x requires `plustan` >= 0.2.5.0 (schema v2 JSON). On a version mismatch, Start Review shows an error with a "Check for Updates" action instead of silently misparsing output.
 
 ## Install In Cursor
 
@@ -37,16 +43,28 @@ cursor --extensionDevelopmentPath=/path/to/plu-stan/vscode-plustan --disable-ext
 
 ## Commands
 
-- `Plu-Stan: Refresh Onchain Modules`
+- `Plu-Stan: Start Review`
+- `Plu-Stan: End Review`
+- `Plu-Stan: Toggle Findings Grouping`
+- `Plu-Stan: Open Finding`
+- `Plu-Stan: Dismiss Finding`
+- `Plu-Stan: Restore Dismissed Finding`
 - `Plu-Stan: Run Workspace`
 - `Plu-Stan: Run Module`
+- `Plu-Stan: Refresh Onchain Modules`
 - `Plu-Stan: Clear Diagnostics`
 - `Plu-Stan: Show Output`
+- `Plu-Stan: Open Settings`
+- `Plu-Stan: Check for Updates`
 
 ## Settings
 
-- `plustan.binaryPath`
-- `plustan.projectDir`
-- `plustan.hieDir`
-- `plustan.extraArgs`
-- `plustan.showOutputChannel`
+- `plustan.binaryPath` — absolute path to the `plustan` executable. Supports a leading `${workspaceFolder}` token, which the extension expands itself (VS Code only expands this in `launch.json`/`tasks.json`, not arbitrary settings). Leave empty to let the extension manage a downloaded binary.
+- `plustan.projectDir` — project directory; defaults to the active workspace folder.
+- `plustan.hieDir` — directory containing `.hie`/`.hi` files, relative to `projectDir` unless absolute.
+- `plustan.extraArgs` — additional CLI arguments appended to `plustan analyze` runs.
+- `plustan.showOutputChannel` — show the Plu-Stan output channel automatically when running commands.
+
+## `.plustan/dismissals.json`
+
+Dismissals are written to `.plustan/dismissals.json` at the workspace root. Commit it to share reviewer decisions across your team, and (in a future phase) to gate CI on unresolved findings.

--- a/vscode-plustan/package-lock.json
+++ b/vscode-plustan/package-lock.json
@@ -1,21 +1,30 @@
 {
   "name": "vscode-plustan",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-plustan",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MPL-2.0",
       "devDependencies": {
+        "@types/mocha": "^10.0.10",
         "@types/node": "^20.14.10",
         "@types/vscode": "^1.90.0",
+        "mocha": "^10.8.2",
         "typescript": "^5.5.4"
       },
       "engines": {
         "vscode": "^1.90.0"
       }
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.33",
@@ -33,6 +42,829 @@
       "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -54,6 +886,106 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/vscode-plustan/package-lock.json
+++ b/vscode-plustan/package-lock.json
@@ -12,6 +12,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^20.14.10",
         "@types/vscode": "^1.90.0",
+        "@vscode/test-electron": "^2.5.2",
         "mocha": "^10.8.2",
         "typescript": "^5.5.4"
       },
@@ -42,6 +43,33 @@
       "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -218,6 +246,35 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -247,6 +304,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -393,6 +457,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
@@ -446,6 +523,41 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -512,6 +624,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -545,6 +670,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
@@ -566,6 +698,29 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/locate-path": {
@@ -596,6 +751,19 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -677,6 +845,156 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -709,6 +1027,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -732,6 +1057,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -741,6 +1073,29 @@
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -765,6 +1120,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -786,6 +1158,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -795,6 +1180,56 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -884,6 +1319,13 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },

--- a/vscode-plustan/package.json
+++ b/vscode-plustan/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-plustan",
   "displayName": "Plu-Stan",
   "description": "Security and performance static analysis for Cardano smart contracts written in Plinth.",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "icon": "media/logo.png",
   "publisher": "IOG",
   "license": "MPL-2.0",

--- a/vscode-plustan/package.json
+++ b/vscode-plustan/package.json
@@ -124,11 +124,14 @@
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
+    "test:unit": "npm run compile && mocha \"out/core/**/*.test.js\" \"out/analyzer/**/*.test.js\"",
     "package:vsix": "npx @vscode/vsce package --readme-path MARKETPLACE.md"
   },
   "devDependencies": {
+    "@types/mocha": "^10.0.10",
     "@types/node": "^20.14.10",
     "@types/vscode": "^1.90.0",
+    "mocha": "^10.8.2",
     "typescript": "^5.5.4"
   }
 }

--- a/vscode-plustan/package.json
+++ b/vscode-plustan/package.json
@@ -24,7 +24,6 @@
     "Linters",
     "Programming Languages"
   ],
-
   "main": "./out/extension.js",
   "activationEvents": [
     "onLanguage:haskell",
@@ -190,12 +189,14 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "test:unit": "npm run compile && mocha \"out/core/**/*.test.js\" \"out/analyzer/**/*.test.js\"",
+    "test:integration": "npm run compile && node out/test/runTest.js",
     "package:vsix": "npx @vscode/vsce package --readme-path MARKETPLACE.md"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.14.10",
     "@types/vscode": "^1.90.0",
+    "@vscode/test-electron": "^2.5.2",
     "mocha": "^10.8.2",
     "typescript": "^5.5.4"
   }

--- a/vscode-plustan/package.json
+++ b/vscode-plustan/package.json
@@ -107,7 +107,8 @@
         {
           "id": "plustanFindingDetail",
           "name": "Finding Detail",
-          "type": "webview"
+          "type": "webview",
+          "visibility": "collapsed"
         },
         {
           "id": "plustanOnchainModules",

--- a/vscode-plustan/package.json
+++ b/vscode-plustan/package.json
@@ -59,6 +59,35 @@
       {
         "command": "plustan.checkForUpdates",
         "title": "Plu-Stan: Check for Updates"
+      },
+      {
+        "command": "plustan.startReview",
+        "title": "Plu-Stan: Start Review",
+        "icon": "$(play)"
+      },
+      {
+        "command": "plustan.endReview",
+        "title": "Plu-Stan: End Review",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "command": "plustan.toggleFindingsGrouping",
+        "title": "Plu-Stan: Toggle Findings Grouping",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "plustan.openFinding",
+        "title": "Plu-Stan: Open Finding"
+      },
+      {
+        "command": "plustan.dismissFinding",
+        "title": "Plu-Stan: Dismiss Finding",
+        "icon": "$(close)"
+      },
+      {
+        "command": "plustan.undismissFinding",
+        "title": "Plu-Stan: Restore Dismissed Finding",
+        "icon": "$(redo)"
       }
     ],
     "viewsContainers": {
@@ -73,17 +102,53 @@
     "views": {
       "plustan": [
         {
+          "id": "plustanFindings",
+          "name": "Findings"
+        },
+        {
+          "id": "plustanFindingDetail",
+          "name": "Finding Detail",
+          "type": "webview"
+        },
+        {
           "id": "plustanOnchainModules",
-          "name": "Plu-Stan Onchain Modules"
+          "name": "Onchain Modules"
         }
       ]
     },
     "menus": {
+      "view/title": [
+        {
+          "command": "plustan.startReview",
+          "when": "view == plustanFindings && plustan.sessionActive != true",
+          "group": "navigation@1"
+        },
+        {
+          "command": "plustan.endReview",
+          "when": "view == plustanFindings && plustan.sessionActive == true",
+          "group": "navigation@1"
+        },
+        {
+          "command": "plustan.toggleFindingsGrouping",
+          "when": "view == plustanFindings",
+          "group": "navigation@2"
+        }
+      ],
       "view/item/context": [
         {
           "command": "plustan.runModule",
           "when": "view == plustanOnchainModules && viewItem == plustanModule",
           "group": "inline@1"
+        },
+        {
+          "command": "plustan.dismissFinding",
+          "when": "view == plustanFindings && viewItem == plustanFinding",
+          "group": "inline"
+        },
+        {
+          "command": "plustan.undismissFinding",
+          "when": "view == plustanFindings && viewItem == plustanDismissedFinding",
+          "group": "inline"
         }
       ]
     },

--- a/vscode-plustan/src/analyzer/client.test.ts
+++ b/vscode-plustan/src/analyzer/client.test.ts
@@ -30,6 +30,25 @@ describe("SpawnAnalyzerClient", () => {
     assert.strictEqual(p.observations.length, 2);
     assert.strictEqual(p.observations[0].fingerprint, "FPR-PLU-STAN-04-aaa-bbb");
   });
+  it("passes --module for module-scoped analysis", async () => {
+    // fake-plustan.js reports runScope "module" only when it sees a literal --module arg,
+    // so this pins the exact flag spelling.
+    const p = await client().analyze({ kind: "module", moduleName: "Fixture.Validator" });
+    assert.strictEqual(p.runScope, "module");
+  });
+  it("lists onchain modules", async () => {
+    const p = await client().listOnchain();
+    assert.strictEqual(p.modules.length, 1);
+    assert.strictEqual(p.modules[0].moduleName, "Fixture.Validator");
+  });
+  it("rejects with kind cancelled when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await assert.rejects(
+      client().capabilities(controller.signal),
+      (e: unknown) => e instanceof AnalyzerError && e.kind === "cancelled"
+    );
+  });
   it("classifies a missing binary as not-found", async () => {
     const bad = new SpawnAnalyzerClient(
       () => ({ binaryPath: "/nonexistent/plustan", binaryPrefixArgs: [], cwd: fixtures, hieDir: ".hie", extraArgs: [] }),
@@ -51,6 +70,10 @@ describe("parseJsonFromOutput", () => {
   });
   it("throws on pure garbage input", () => {
     assert.throws(() => parseJsonFromOutput("not json at all\nstill not json\n"));
+  });
+  it("does not let a stray numeric noise line shadow the payload", () => {
+    const stdout = JSON.stringify({ ok: true }) + "\n42\n";
+    assert.deepStrictEqual(parseJsonFromOutput(stdout), { ok: true });
   });
 });
 

--- a/vscode-plustan/src/analyzer/client.test.ts
+++ b/vscode-plustan/src/analyzer/client.test.ts
@@ -1,0 +1,74 @@
+import * as assert from "node:assert";
+import * as path from "node:path";
+import { AnalyzerError, SpawnAnalyzerClient, classifyNoJsonFailure, parseJsonFromOutput } from "./client";
+
+// out/analyzer/client.test.js → repo fixture dir
+const fixtures = path.resolve(__dirname, "..", "..", "test-fixtures");
+const fakeBinary = process.execPath; // node itself
+const fakeScript = path.join(fixtures, "fake-plustan.js");
+
+function client(extraArgs: string[] = []): SpawnAnalyzerClient {
+  return new SpawnAnalyzerClient(
+    () => ({
+      binaryPath: fakeBinary,
+      binaryPrefixArgs: [fakeScript], // test seam: lets node run the stub script
+      cwd: fixtures,
+      hieDir: ".hie",
+      extraArgs
+    }),
+    () => { /* silent log */ }
+  );
+}
+
+describe("SpawnAnalyzerClient", () => {
+  it("fetches and validates capabilities", async () => {
+    const caps = await client().capabilities();
+    assert.strictEqual(caps.schemaVersion, 2);
+  });
+  it("analyzes and returns a validated v2 payload", async () => {
+    const p = await client().analyze({ kind: "workspace" });
+    assert.strictEqual(p.observations.length, 2);
+    assert.strictEqual(p.observations[0].fingerprint, "FPR-PLU-STAN-04-aaa-bbb");
+  });
+  it("classifies a missing binary as not-found", async () => {
+    const bad = new SpawnAnalyzerClient(
+      () => ({ binaryPath: "/nonexistent/plustan", binaryPrefixArgs: [], cwd: fixtures, hieDir: ".hie", extraArgs: [] }),
+      () => { /* silent */ }
+    );
+    await assert.rejects(bad.capabilities(), (e: unknown) => e instanceof AnalyzerError && e.kind === "not-found");
+  });
+});
+
+describe("parseJsonFromOutput", () => {
+  it("finds JSON preceded by build noise", () => {
+    const stdout = "Compiling Foo.hs\nLinking...\n" + JSON.stringify({ ok: true });
+    assert.deepStrictEqual(parseJsonFromOutput(stdout), { ok: true });
+  });
+  it("finds JSON followed by trailing noise lines", () => {
+    const stdout = JSON.stringify({ ok: true }) + "\nsome trailer that is not json\n";
+    // Trailing non-JSON line means scanning from the end skips it and finds the JSON line before it.
+    assert.deepStrictEqual(parseJsonFromOutput(stdout), { ok: true });
+  });
+  it("throws on pure garbage input", () => {
+    assert.throws(() => parseJsonFromOutput("not json at all\nstill not json\n"));
+  });
+});
+
+describe("classifyNoJsonFailure", () => {
+  it("classifies GHC .hie version mismatches", () => {
+    const err = classifyNoJsonFailure("", "Error: hie file versions do not match\n", 1);
+    assert.strictEqual(err.kind, "ghc-mismatch");
+  });
+  it("classifies GHC panics as crash", () => {
+    const err = classifyNoJsonFailure("", "ghc: panic! (the 'impossible' happened)\n", 1);
+    assert.strictEqual(err.kind, "crash");
+  });
+  it("classifies a failing internal build as build-failed", () => {
+    const err = classifyNoJsonFailure("", "src/Foo.hs:3:1: error: Parse error\n", 1);
+    assert.strictEqual(err.kind, "build-failed");
+  });
+  it("falls back to no-json for an unrecognized silent failure", () => {
+    const err = classifyNoJsonFailure("", "unknown command bogus\n", 1);
+    assert.strictEqual(err.kind, "no-json");
+  });
+});

--- a/vscode-plustan/src/analyzer/client.ts
+++ b/vscode-plustan/src/analyzer/client.ts
@@ -1,0 +1,148 @@
+import { spawn } from "node:child_process";
+import {
+  AnalyzePayloadV2, CapabilitiesPayload, ListOnchainPayload,
+  parseAnalyzePayload, parseCapabilities, parseListOnchain
+} from "../core/schema";
+
+export type AnalyzeScope = { kind: "workspace" } | { kind: "module"; moduleName: string };
+
+export type AnalyzerErrorKind =
+  | "not-found"        // binary missing (ENOENT)
+  | "ghc-mismatch"     // .hie files built by a different GHC
+  | "build-failed"     // cabal build inside plustan failed
+  | "crash"            // GHC panic
+  | "no-json";         // anything else that produced no usable JSON
+
+export class AnalyzerError extends Error {
+  constructor(readonly kind: AnalyzerErrorKind, message: string) {
+    super(message);
+    this.name = "AnalyzerError";
+  }
+}
+
+export interface SpawnConfig {
+  binaryPath: string;
+  /** Args inserted before the subcommand — empty in production, used by tests to run `node fake-plustan.js …`. */
+  binaryPrefixArgs: string[];
+  cwd: string;
+  hieDir: string;
+  extraArgs: string[];
+}
+
+export interface AnalyzerClient {
+  capabilities(signal?: AbortSignal): Promise<CapabilitiesPayload>;
+  listOnchain(signal?: AbortSignal): Promise<ListOnchainPayload>;
+  analyze(scope: AnalyzeScope, signal?: AbortSignal): Promise<AnalyzePayloadV2>;
+}
+
+export class SpawnAnalyzerClient implements AnalyzerClient {
+  constructor(
+    private readonly getConfig: () => SpawnConfig,
+    private readonly log: (line: string) => void
+  ) {}
+
+  async capabilities(signal?: AbortSignal): Promise<CapabilitiesPayload> {
+    return parseCapabilities(await this.runJson(["capabilities"], signal));
+  }
+
+  async listOnchain(signal?: AbortSignal): Promise<ListOnchainPayload> {
+    const config = this.getConfig();
+    return parseListOnchain(await this.runJson(["list-onchain", "--json", "--hiedir", config.hieDir], signal));
+  }
+
+  async analyze(scope: AnalyzeScope, signal?: AbortSignal): Promise<AnalyzePayloadV2> {
+    const config = this.getConfig();
+    const args = ["analyze", "--json", "--hiedir", config.hieDir, ...config.extraArgs];
+    if (scope.kind === "module") {
+      args.push("--module", scope.moduleName);
+    }
+    return parseAnalyzePayload(await this.runJson(args, signal));
+  }
+
+  private async runJson(args: string[], signal?: AbortSignal): Promise<unknown> {
+    const config = this.getConfig();
+    const fullArgs = [...config.binaryPrefixArgs, ...args];
+    this.log(`$ ${config.binaryPath} ${fullArgs.join(" ")}`);
+
+    const { stdout, stderr, exitCode } = await this.spawnOnce(config, fullArgs, signal);
+
+    let parsed: unknown;
+    try {
+      parsed = parseJsonFromOutput(stdout);
+    } catch {
+      throw classifyNoJsonFailure(stdout, stderr, exitCode);
+    }
+    if (exitCode !== 0) {
+      this.log(`plustan exited with code ${exitCode}; using emitted JSON payload.`);
+    }
+    return parsed;
+  }
+
+  private spawnOnce(
+    config: SpawnConfig,
+    args: string[],
+    signal?: AbortSignal
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(config.binaryPath, args, { cwd: config.cwd, env: process.env });
+      let stdout = "";
+      let stderr = "";
+      const onAbort = (): void => {
+        child.kill("SIGTERM");
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+
+      child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf8"); });
+      child.stderr.on("data", (chunk: Buffer) => {
+        const text = chunk.toString("utf8");
+        stderr += text;
+        this.log(text.trimEnd());
+      });
+      child.on("error", (error: NodeJS.ErrnoException) => {
+        signal?.removeEventListener("abort", onAbort);
+        if (error.code === "ENOENT") {
+          reject(new AnalyzerError("not-found",
+            `Plu-Stan binary not found: ${config.binaryPath}. Set \`plustan.binaryPath\` or run "Plu-Stan: Check for Updates".`));
+        } else {
+          reject(new AnalyzerError("no-json", `Failed to start plustan: ${error.message}`));
+        }
+      });
+      child.on("close", (code) => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve({ stdout, stderr, exitCode: code ?? 1 });
+      });
+    });
+  }
+}
+
+/** Scan stdout lines from the end for the JSON payload (build noise may precede it). */
+export function parseJsonFromOutput(stdout: string): unknown {
+  const lines = stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    try {
+      return JSON.parse(lines[i]);
+    } catch {
+      // keep scanning earlier lines
+    }
+  }
+  return JSON.parse(stdout);
+}
+
+/** Turn a no-JSON plustan run into a typed, user-actionable error. */
+export function classifyNoJsonFailure(stdout: string, stderr: string, exitCode: number): AnalyzerError {
+  const haystack = `${stderr}\n${stdout}`;
+  if (/hie file versions|readHieFile|built by a different ghc|different ghc/i.test(haystack)) {
+    return new AnalyzerError("ghc-mismatch",
+      "Plu-Stan couldn't read your project's .hie files: they were built with a different GHC than the plustan binary. " +
+      "Rebuild with the matching GHC, or run \"Plu-Stan: Check for Updates\".");
+  }
+  if (/panic!|the 'impossible' happened/i.test(haystack)) {
+    return new AnalyzerError("crash", `Plu-Stan crashed (exit ${exitCode}). See the Plu-Stan output channel.`);
+  }
+  if (exitCode !== 0 && /error:|\[error\]/i.test(stderr)) {
+    return new AnalyzerError("build-failed",
+      "The project build failed, so analysis could not run. Fix the compile errors and save again.");
+  }
+  return new AnalyzerError("no-json",
+    `Plu-Stan produced no JSON output (exit ${exitCode}). The binary may be outdated — try "Plu-Stan: Check for Updates".`);
+}

--- a/vscode-plustan/src/analyzer/client.ts
+++ b/vscode-plustan/src/analyzer/client.ts
@@ -11,6 +11,7 @@ export type AnalyzerErrorKind =
   | "ghc-mismatch"     // .hie files built by a different GHC
   | "build-failed"     // cabal build inside plustan failed
   | "crash"            // GHC panic
+  | "cancelled"        // run was aborted by the caller; callers should swallow it silently
   | "no-json";         // anything else that produced no usable JSON
 
 export class AnalyzerError extends Error {
@@ -60,11 +61,20 @@ export class SpawnAnalyzerClient implements AnalyzerClient {
   }
 
   private async runJson(args: string[], signal?: AbortSignal): Promise<unknown> {
+    if (signal?.aborted) {
+      throw new AnalyzerError("cancelled", "Plu-Stan run cancelled.");
+    }
     const config = this.getConfig();
     const fullArgs = [...config.binaryPrefixArgs, ...args];
     this.log(`$ ${config.binaryPath} ${fullArgs.join(" ")}`);
 
     const { stdout, stderr, exitCode } = await this.spawnOnce(config, fullArgs, signal);
+
+    // A cancelled run's output is meaningless (usually truncated by SIGTERM);
+    // don't let it fall through to the "binary may be outdated" classifier.
+    if (signal?.aborted) {
+      throw new AnalyzerError("cancelled", "Plu-Stan run cancelled.");
+    }
 
     let parsed: unknown;
     try {
@@ -91,6 +101,10 @@ export class SpawnAnalyzerClient implements AnalyzerClient {
         child.kill("SIGTERM");
       };
       signal?.addEventListener("abort", onAbort, { once: true });
+      // addEventListener does NOT fire for an already-aborted signal; kill immediately.
+      if (signal?.aborted) {
+        onAbort();
+      }
 
       child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf8"); });
       child.stderr.on("data", (chunk: Buffer) => {
@@ -120,7 +134,11 @@ export function parseJsonFromOutput(stdout: string): unknown {
   const lines = stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
   for (let i = lines.length - 1; i >= 0; i -= 1) {
     try {
-      return JSON.parse(lines[i]);
+      const parsed: unknown = JSON.parse(lines[i]);
+      // Only object payloads count: a stray numeric/quoted noise line must not shadow the real payload.
+      if (typeof parsed === "object" && parsed !== null) {
+        return parsed;
+      }
     } catch {
       // keep scanning earlier lines
     }
@@ -131,7 +149,7 @@ export function parseJsonFromOutput(stdout: string): unknown {
 /** Turn a no-JSON plustan run into a typed, user-actionable error. */
 export function classifyNoJsonFailure(stdout: string, stderr: string, exitCode: number): AnalyzerError {
   const haystack = `${stderr}\n${stdout}`;
-  if (/hie file versions|readHieFile|built by a different ghc|different ghc/i.test(haystack)) {
+  if (/hie file versions|readHieFile|different ghc/i.test(haystack)) {
     return new AnalyzerError("ghc-mismatch",
       "Plu-Stan couldn't read your project's .hie files: they were built with a different GHC than the plustan binary. " +
       "Rebuild with the matching GHC, or run \"Plu-Stan: Check for Updates\".");

--- a/vscode-plustan/src/core/dismissals.test.ts
+++ b/vscode-plustan/src/core/dismissals.test.ts
@@ -1,0 +1,26 @@
+import * as assert from "node:assert";
+import { addDismissal, emptyDismissals, parseDismissals, removeDismissal, serializeDismissals } from "./dismissals";
+
+describe("dismissals", () => {
+  it("round-trips through serialize/parse", () => {
+    const d1 = addDismissal(emptyDismissals(), {
+      fingerprint: "f1", inspectionId: "PLU-STAN-04", note: "intentional", dismissedAt: "2026-07-06T10:00:00Z"
+    });
+    const d2 = parseDismissals(serializeDismissals(d1));
+    assert.deepStrictEqual(d2, d1);
+  });
+  it("dedupes by fingerprint", () => {
+    const base = addDismissal(emptyDismissals(), { fingerprint: "f1", inspectionId: "X", dismissedAt: "t" });
+    const twice = addDismissal(base, { fingerprint: "f1", inspectionId: "X", dismissedAt: "t2" });
+    assert.strictEqual(twice.dismissals.length, 1);
+    assert.strictEqual(twice.dismissals[0].dismissedAt, "t2");
+  });
+  it("removes by fingerprint", () => {
+    const base = addDismissal(emptyDismissals(), { fingerprint: "f1", inspectionId: "X", dismissedAt: "t" });
+    assert.strictEqual(removeDismissal(base, "f1").dismissals.length, 0);
+  });
+  it("tolerates broken file content", () => {
+    assert.deepStrictEqual(parseDismissals("not json {"), emptyDismissals());
+    assert.deepStrictEqual(parseDismissals('{"version":1}'), emptyDismissals());
+  });
+});

--- a/vscode-plustan/src/core/dismissals.test.ts
+++ b/vscode-plustan/src/core/dismissals.test.ts
@@ -23,4 +23,17 @@ describe("dismissals", () => {
     assert.deepStrictEqual(parseDismissals("not json {"), emptyDismissals());
     assert.deepStrictEqual(parseDismissals('{"version":1}'), emptyDismissals());
   });
+  it("drops malformed entries but keeps valid ones", () => {
+    const parsed = parseDismissals(
+      '{"version":1,"dismissals":[{"fingerprint":"f1","inspectionId":"X","dismissedAt":"t"},{"note":"garbage, no fingerprint"}]}'
+    );
+    assert.strictEqual(parsed.dismissals.length, 1);
+    assert.strictEqual(parsed.dismissals[0].fingerprint, "f1");
+  });
+  it("moves a re-added entry to the end", () => {
+    let d = addDismissal(emptyDismissals(), { fingerprint: "f1", inspectionId: "X", dismissedAt: "t1" });
+    d = addDismissal(d, { fingerprint: "f2", inspectionId: "X", dismissedAt: "t2" });
+    d = addDismissal(d, { fingerprint: "f1", inspectionId: "X", dismissedAt: "t3" });
+    assert.deepStrictEqual(d.dismissals.map((e) => e.fingerprint), ["f2", "f1"]);
+  });
 });

--- a/vscode-plustan/src/core/dismissals.ts
+++ b/vscode-plustan/src/core/dismissals.ts
@@ -1,0 +1,48 @@
+export interface DismissalEntry {
+  fingerprint: string;
+  inspectionId: string;
+  note?: string;
+  dismissedAt: string;
+}
+
+export interface DismissalsFile {
+  version: 1;
+  dismissals: DismissalEntry[];
+}
+
+export function emptyDismissals(): DismissalsFile {
+  return { version: 1, dismissals: [] };
+}
+
+export function parseDismissals(text: string): DismissalsFile {
+  try {
+    const raw = JSON.parse(text) as { version?: unknown; dismissals?: unknown };
+    if (!Array.isArray(raw.dismissals)) {
+      return emptyDismissals();
+    }
+    const dismissals = raw.dismissals.filter(
+      (d): d is DismissalEntry =>
+        typeof d === "object" && d !== null &&
+        typeof (d as DismissalEntry).fingerprint === "string" &&
+        typeof (d as DismissalEntry).inspectionId === "string"
+    );
+    return { version: 1, dismissals };
+  } catch {
+    return emptyDismissals();
+  }
+}
+
+export function serializeDismissals(file: DismissalsFile): string {
+  return JSON.stringify(file, null, 2) + "\n";
+}
+
+export function addDismissal(file: DismissalsFile, entry: DismissalEntry): DismissalsFile {
+  return {
+    version: 1,
+    dismissals: [...file.dismissals.filter((d) => d.fingerprint !== entry.fingerprint), entry]
+  };
+}
+
+export function removeDismissal(file: DismissalsFile, fingerprint: string): DismissalsFile {
+  return { version: 1, dismissals: file.dismissals.filter((d) => d.fingerprint !== fingerprint) };
+}

--- a/vscode-plustan/src/core/runCoalescer.test.ts
+++ b/vscode-plustan/src/core/runCoalescer.test.ts
@@ -1,0 +1,33 @@
+import * as assert from "node:assert";
+import { RunCoalescer } from "./runCoalescer";
+
+describe("RunCoalescer", () => {
+  it("coalesces duplicate module requests", () => {
+    const q = new RunCoalescer();
+    q.request({ kind: "module", moduleName: "A" });
+    q.request({ kind: "module", moduleName: "A" });
+    q.request({ kind: "module", moduleName: "B" });
+    assert.strictEqual(q.size, 2);
+  });
+  it("a workspace request subsumes all pending module requests", () => {
+    const q = new RunCoalescer();
+    q.request({ kind: "module", moduleName: "A" });
+    q.request({ kind: "workspace" });
+    assert.strictEqual(q.size, 1);
+    assert.deepStrictEqual(q.takeNext(), { kind: "workspace" });
+  });
+  it("module requests while a workspace run is pending are absorbed", () => {
+    const q = new RunCoalescer();
+    q.request({ kind: "workspace" });
+    q.request({ kind: "module", moduleName: "A" });
+    assert.strictEqual(q.size, 1);
+  });
+  it("serves FIFO otherwise", () => {
+    const q = new RunCoalescer();
+    q.request({ kind: "module", moduleName: "A" });
+    q.request({ kind: "module", moduleName: "B" });
+    assert.deepStrictEqual(q.takeNext(), { kind: "module", moduleName: "A" });
+    assert.deepStrictEqual(q.takeNext(), { kind: "module", moduleName: "B" });
+    assert.strictEqual(q.takeNext(), undefined);
+  });
+});

--- a/vscode-plustan/src/core/runCoalescer.ts
+++ b/vscode-plustan/src/core/runCoalescer.ts
@@ -1,0 +1,27 @@
+export type PendingRun = { kind: "workspace" } | { kind: "module"; moduleName: string };
+
+/** Pending analysis runs: duplicates coalesce, workspace subsumes modules. */
+export class RunCoalescer {
+  private pending: PendingRun[] = [];
+
+  request(run: PendingRun): void {
+    if (this.pending.some((p) => p.kind === "workspace")) {
+      return; // a pending workspace run already covers everything
+    }
+    if (run.kind === "workspace") {
+      this.pending = [{ kind: "workspace" }];
+      return;
+    }
+    if (!this.pending.some((p) => p.kind === "module" && p.moduleName === run.moduleName)) {
+      this.pending.push(run);
+    }
+  }
+
+  takeNext(): PendingRun | undefined {
+    return this.pending.shift();
+  }
+
+  get size(): number {
+    return this.pending.length;
+  }
+}

--- a/vscode-plustan/src/core/sanity.test.ts
+++ b/vscode-plustan/src/core/sanity.test.ts
@@ -1,0 +1,7 @@
+import * as assert from "node:assert";
+
+describe("test infrastructure", () => {
+  it("runs", () => {
+    assert.strictEqual(1 + 1, 2);
+  });
+});

--- a/vscode-plustan/src/core/schema.test.ts
+++ b/vscode-plustan/src/core/schema.test.ts
@@ -1,0 +1,45 @@
+import * as assert from "node:assert";
+import { parseAnalyzePayload, parseCapabilities, SchemaError } from "./schema";
+
+const validPayload = {
+  version: 2,
+  runScope: "all",
+  targetModule: null,
+  inspections: [{
+    id: "PLU-STAN-04", name: "Credential eq", description: "d", solution: ["s"],
+    category: ["Plutus"], severity: "Warning",
+    whyItMatters: "w", badExample: "b", goodExample: "g", docsAnchor: "equality"
+  }],
+  observations: [{
+    id: "o1", inspectionId: "PLU-STAN-04", fingerprint: "FPR-PLU-STAN-04-abc-def",
+    file: "src/V.hs", moduleName: "V", startLine: 4, startCol: 1, endLine: 4, endCol: 10
+  }]
+};
+
+describe("schema", () => {
+  it("parses a valid v2 analyze payload", () => {
+    const p = parseAnalyzePayload(validPayload);
+    assert.strictEqual(p.observations[0].fingerprint, "FPR-PLU-STAN-04-abc-def");
+    assert.strictEqual(p.inspections[0].whyItMatters, "w");
+  });
+  it("rejects v1 payloads as unsupported-version", () => {
+    assert.throws(
+      () => parseAnalyzePayload({ version: 1, inspections: [], analysis: { observations: [] } }),
+      (e: unknown) => e instanceof SchemaError && e.reason === "unsupported-version"
+    );
+  });
+  it("rejects structurally broken payloads as malformed", () => {
+    assert.throws(
+      () => parseAnalyzePayload({ version: 2, runScope: "all", targetModule: null, inspections: [] }),
+      (e: unknown) => e instanceof SchemaError && e.reason === "malformed"
+    );
+  });
+  it("parses capabilities and rejects wrong schemaVersion", () => {
+    const c = parseCapabilities({ schemaVersion: 2, ghcVersion: "9.6", features: ["fingerprints"] });
+    assert.strictEqual(c.schemaVersion, 2);
+    assert.throws(
+      () => parseCapabilities({ schemaVersion: 3, features: [] }),
+      (e: unknown) => e instanceof SchemaError && e.reason === "unsupported-version"
+    );
+  });
+});

--- a/vscode-plustan/src/core/schema.test.ts
+++ b/vscode-plustan/src/core/schema.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "node:assert";
-import { parseAnalyzePayload, parseCapabilities, SchemaError } from "./schema";
+import { parseAnalyzePayload, parseCapabilities, parseListOnchain, SchemaError } from "./schema";
 
 const validPayload = {
   version: 2,
@@ -40,6 +40,31 @@ describe("schema", () => {
     assert.throws(
       () => parseCapabilities({ schemaVersion: 3, features: [] }),
       (e: unknown) => e instanceof SchemaError && e.reason === "unsupported-version"
+    );
+  });
+  it("rejects inspections without a string id as malformed", () => {
+    assert.throws(
+      () => parseAnalyzePayload({
+        version: 2, runScope: "all", targetModule: null,
+        inspections: [{ name: "x" }], observations: []
+      }),
+      (e: unknown) => e instanceof SchemaError && e.reason === "malformed"
+    );
+  });
+  it("parses list-onchain payloads version-agnostically", () => {
+    const p = parseListOnchain({
+      version: 1,
+      workspaceRoot: "/ws",
+      hieDir: ".hie",
+      modules: [{ moduleName: "V", file: "src/V.hs", annotationSource: "hi" }]
+    });
+    assert.strictEqual(p.modules.length, 1);
+    assert.strictEqual(p.modules[0].moduleName, "V");
+  });
+  it("rejects list-onchain payloads without a modules array as malformed", () => {
+    assert.throws(
+      () => parseListOnchain({ version: 2, workspaceRoot: "/ws", hieDir: ".hie" }),
+      (e: unknown) => e instanceof SchemaError && e.reason === "malformed"
     );
   });
 });

--- a/vscode-plustan/src/core/schema.ts
+++ b/vscode-plustan/src/core/schema.ts
@@ -1,0 +1,93 @@
+export const SUPPORTED_SCHEMA_VERSION = 2;
+
+export interface InspectionV2 {
+  id: string; name: string; description: string;
+  solution: string[]; category: string[]; severity: string;
+  whyItMatters?: string; badExample?: string; goodExample?: string; docsAnchor?: string;
+}
+
+export interface ObservationV2 {
+  id: string; inspectionId: string; fingerprint: string;
+  file: string; moduleName: string;
+  startLine: number; startCol: number; endLine: number; endCol: number;
+}
+
+export interface AnalyzePayloadV2 {
+  version: number;
+  runScope: "all" | "module";
+  targetModule: string | null;
+  inspections: InspectionV2[];
+  observations: ObservationV2[];
+}
+
+export interface CapabilitiesPayload {
+  schemaVersion: number;
+  ghcVersion?: string;
+  features: string[];
+}
+
+export interface OnchainModule { moduleName: string; file: string; annotationSource: string; }
+export interface ListOnchainPayload { version: number; workspaceRoot: string; hieDir: string; modules: OnchainModule[]; }
+
+export class SchemaError extends Error {
+  constructor(readonly reason: "unsupported-version" | "malformed", message: string) {
+    super(message);
+    this.name = "SchemaError";
+  }
+}
+
+function asRecord(raw: unknown, what: string): Record<string, unknown> {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new SchemaError("malformed", `${what} is not an object`);
+  }
+  return raw as Record<string, unknown>;
+}
+
+function requireVersion(actual: unknown, what: string): void {
+  if (actual !== SUPPORTED_SCHEMA_VERSION) {
+    throw new SchemaError(
+      "unsupported-version",
+      `${what} has schema version ${String(actual)}; this extension requires ${SUPPORTED_SCHEMA_VERSION}. ` +
+      `Run "Plu-Stan: Check for Updates" to fetch a matching binary.`
+    );
+  }
+}
+
+export function parseAnalyzePayload(raw: unknown): AnalyzePayloadV2 {
+  const o = asRecord(raw, "analyze payload");
+  requireVersion(o.version, "analyze payload");
+  if (!Array.isArray(o.inspections) || !Array.isArray(o.observations)) {
+    throw new SchemaError("malformed", "analyze payload: missing inspections/observations arrays");
+  }
+  for (const obs of o.observations) {
+    const r = asRecord(obs, "observation");
+    for (const key of ["fingerprint", "inspectionId", "file", "moduleName"]) {
+      if (typeof r[key] !== "string") {
+        throw new SchemaError("malformed", `observation: missing string field '${key}'`);
+      }
+    }
+    for (const key of ["startLine", "startCol", "endLine", "endCol"]) {
+      if (typeof r[key] !== "number") {
+        throw new SchemaError("malformed", `observation: missing numeric field '${key}'`);
+      }
+    }
+  }
+  return o as unknown as AnalyzePayloadV2;
+}
+
+export function parseCapabilities(raw: unknown): CapabilitiesPayload {
+  const o = asRecord(raw, "capabilities payload");
+  requireVersion(o.schemaVersion, "plustan binary");
+  if (!Array.isArray(o.features)) {
+    throw new SchemaError("malformed", "capabilities payload: missing features array");
+  }
+  return o as unknown as CapabilitiesPayload;
+}
+
+export function parseListOnchain(raw: unknown): ListOnchainPayload {
+  const o = asRecord(raw, "list-onchain payload");
+  if (!Array.isArray(o.modules)) {
+    throw new SchemaError("malformed", "list-onchain payload: missing modules array");
+  }
+  return o as unknown as ListOnchainPayload;
+}

--- a/vscode-plustan/src/core/schema.ts
+++ b/vscode-plustan/src/core/schema.ts
@@ -59,6 +59,12 @@ export function parseAnalyzePayload(raw: unknown): AnalyzePayloadV2 {
   if (!Array.isArray(o.inspections) || !Array.isArray(o.observations)) {
     throw new SchemaError("malformed", "analyze payload: missing inspections/observations arrays");
   }
+  for (const insp of o.inspections) {
+    const r = asRecord(insp, "inspection");
+    if (typeof r.id !== "string") {
+      throw new SchemaError("malformed", "inspection: missing string field 'id'");
+    }
+  }
   for (const obs of o.observations) {
     const r = asRecord(obs, "observation");
     for (const key of ["fingerprint", "inspectionId", "file", "moduleName"]) {
@@ -84,6 +90,10 @@ export function parseCapabilities(raw: unknown): CapabilitiesPayload {
   return o as unknown as CapabilitiesPayload;
 }
 
+// Deliberately version-agnostic: the list-onchain shape is identical across
+// schema v1/v2, and `plustan capabilities` is the version gate for the session.
+// list-onchain must keep working against older binaries for the legacy
+// module-listing commands, so no version check here.
 export function parseListOnchain(raw: unknown): ListOnchainPayload {
   const o = asRecord(raw, "list-onchain payload");
   if (!Array.isArray(o.modules)) {

--- a/vscode-plustan/src/core/sessionState.test.ts
+++ b/vscode-plustan/src/core/sessionState.test.ts
@@ -116,4 +116,14 @@ describe("session reducer", () => {
     assert.strictEqual(s2.phase, "active");
     assert.strictEqual(s2.runCount, 0);
   });
+
+  it("freezes lastSeenRun at the last run that reported the finding", () => {
+    const s1 = afterRun(started(), [obs("f1")]);
+    assert.strictEqual(s1.findings["f1"].lastSeenRun, 1);
+    // Run 2 covers src/V.hs but does not report f1; it reports f2 instead.
+    const s2 = afterRun(s1, [obs("f2", "src/V.hs", 7)]);
+    assert.strictEqual(s2.findings["f1"].status, "fixed");
+    assert.strictEqual(s2.findings["f1"].lastSeenRun, 1, "f1 keeps the run it was last reported in");
+    assert.strictEqual(s2.findings["f2"].lastSeenRun, 2, "f2 was reported in run 2");
+  });
 });

--- a/vscode-plustan/src/core/sessionState.test.ts
+++ b/vscode-plustan/src/core/sessionState.test.ts
@@ -132,6 +132,30 @@ describe("session reducer", () => {
     assert.strictEqual(s2.runCount, 0);
   });
 
+  it("findingDismissed with a note sets dismissalNote; findingUndismissed clears it", () => {
+    const s1 = afterRun(started(), [obs("f1")]);
+    const s2 = reduceSession(s1, { type: "findingDismissed", fingerprint: "f1", note: "intentional" });
+    assert.strictEqual(s2.findings["f1"].status, "dismissed");
+    assert.strictEqual(s2.findings["f1"].dismissalNote, "intentional");
+    const s3 = reduceSession(s2, { type: "findingUndismissed", fingerprint: "f1" });
+    assert.strictEqual(s3.findings["f1"].status, "open");
+    assert.strictEqual(s3.findings["f1"].dismissalNote, undefined);
+  });
+
+  it("runCompleted maps dismissalNotes onto a re-reported-and-dismissed finding", () => {
+    const s1 = afterRun(started(), [obs("f1")], ["f1"]);
+    assert.strictEqual(s1.findings["f1"].dismissalNote, undefined);
+    const s2 = reduceSession(s1, {
+      type: "runCompleted",
+      coveredFiles: ["src/V.hs"],
+      observations: [obs("f1")],
+      dismissedFingerprints: ["f1"],
+      dismissalNotes: { f1: "credential-only comparison is intentional here" }
+    });
+    assert.strictEqual(s2.findings["f1"].status, "dismissed");
+    assert.strictEqual(s2.findings["f1"].dismissalNote, "credential-only comparison is intentional here");
+  });
+
   it("freezes lastSeenRun at the last run that reported the finding", () => {
     const s1 = afterRun(started(), [obs("f1")]);
     assert.strictEqual(s1.findings["f1"].lastSeenRun, 1);

--- a/vscode-plustan/src/core/sessionState.test.ts
+++ b/vscode-plustan/src/core/sessionState.test.ts
@@ -94,6 +94,21 @@ describe("session reducer", () => {
     assert.strictEqual(s3.findings["f1"].status, "fixed");
   });
 
+  it("fileEdited returns the SAME state reference when no open finding transitions", () => {
+    // f1 is fixed in src/V.hs; g1 lives in another file. Editing src/V.hs must
+    // stale nothing, so callers can skip re-persisting on this no-op edit.
+    const s1 = afterRun(started(), [obs("f1"), obs("g1", "src/Other.hs")]);
+    const fixed = afterRun(s1, [obs("g1", "src/Other.hs")]); // f1 -> fixed, g1 carried forward
+    assert.strictEqual(fixed.findings["f1"].status, "fixed");
+    // Edit a file with no open findings of its own.
+    const edited = reduceSession(fixed, { type: "fileEdited", file: "src/V.hs" });
+    assert.strictEqual(edited, fixed, "no-op fileEdited must return the identical reference");
+    // And editing a file with an open finding still produces a new reference.
+    const editedOther = reduceSession(fixed, { type: "fileEdited", file: "src/Other.hs" });
+    assert.notStrictEqual(editedOther, fixed, "a real transition must return a new reference");
+    assert.strictEqual(editedOther.findings["g1"].status, "stale");
+  });
+
   it("counts totals across a mixed state", () => {
     const s1 = afterRun(started(), [obs("f1"), obs("f2", "src/V.hs", 7), obs("f3", "src/V.hs", 9)]);
     const s2 = reduceSession(s1, { type: "findingDismissed", fingerprint: "f3" });

--- a/vscode-plustan/src/core/sessionState.test.ts
+++ b/vscode-plustan/src/core/sessionState.test.ts
@@ -1,0 +1,119 @@
+import * as assert from "node:assert";
+import { countByStatus, initialSessionState, reduceSession, SessionState } from "./sessionState";
+import { ObservationV2 } from "./schema";
+
+const obs = (fingerprint: string, file = "src/V.hs", line = 3): ObservationV2 => ({
+  id: "o", inspectionId: "PLU-STAN-04", fingerprint,
+  file, moduleName: "V", startLine: line, startCol: 1, endLine: line, endCol: 10
+});
+
+const started = (): SessionState =>
+  reduceSession(initialSessionState, { type: "sessionStarted", startedAt: "2026-07-06T10:00:00Z" });
+
+const afterRun = (state: SessionState, observations: ObservationV2[], dismissed: string[] = []): SessionState =>
+  reduceSession(state, { type: "runCompleted", coveredFiles: ["src/V.hs"], observations, dismissedFingerprints: dismissed });
+
+describe("session reducer", () => {
+  it("marks findings from a run as open", () => {
+    const s = afterRun(started(), [obs("f1"), obs("f2", "src/V.hs", 7)]);
+    assert.strictEqual(countByStatus(s).open, 2);
+  });
+  it("marks a finding fixed when a later run over its file no longer reports it", () => {
+    const s1 = afterRun(started(), [obs("f1"), obs("f2", "src/V.hs", 7)]);
+    const s2 = afterRun(s1, [obs("f2", "src/V.hs", 7)]);
+    assert.strictEqual(s2.findings["f1"].status, "fixed");
+    assert.strictEqual(s2.findings["f2"].status, "open");
+  });
+  it("does not touch findings in files not covered by the run", () => {
+    const s1 = afterRun(started(), [obs("f1"), obs("g1", "src/Other.hs")]);
+    const s2 = afterRun(s1, []); // covers only src/V.hs
+    assert.strictEqual(s2.findings["f1"].status, "fixed");
+    assert.strictEqual(s2.findings["g1"].status, "open");
+  });
+  it("marks open findings stale when their file is edited, and re-opens on re-run", () => {
+    const s1 = afterRun(started(), [obs("f1")]);
+    const s2 = reduceSession(s1, { type: "fileEdited", file: "src/V.hs" });
+    assert.strictEqual(s2.findings["f1"].status, "stale");
+    const s3 = afterRun(s2, [obs("f1")]);
+    assert.strictEqual(s3.findings["f1"].status, "open");
+  });
+  it("applies and persists dismissals across runs", () => {
+    const s1 = afterRun(started(), [obs("f1")], ["f1"]);
+    assert.strictEqual(s1.findings["f1"].status, "dismissed");
+    const s2 = afterRun(s1, [obs("f1")], ["f1"]);
+    assert.strictEqual(s2.findings["f1"].status, "dismissed");
+  });
+  it("dismisses and undismisses interactively", () => {
+    const s1 = afterRun(started(), [obs("f1")]);
+    const s2 = reduceSession(s1, { type: "findingDismissed", fingerprint: "f1" });
+    assert.strictEqual(s2.findings["f1"].status, "dismissed");
+    const s3 = reduceSession(s2, { type: "findingUndismissed", fingerprint: "f1" });
+    assert.strictEqual(s3.findings["f1"].status, "open");
+  });
+  it("ends the session back to idle but keeps findings for the summary", () => {
+    const s = reduceSession(afterRun(started(), [obs("f1")]), { type: "sessionEnded" });
+    assert.strictEqual(s.phase, "idle");
+    assert.strictEqual(Object.keys(s.findings).length, 1);
+  });
+
+  // --- Extra tests pinning subtler reducer behavior ---
+
+  it("does not resurrect a dismissed finding as fixed when a later covering run omits it", () => {
+    const s1 = afterRun(started(), [obs("f1")], ["f1"]);
+    assert.strictEqual(s1.findings["f1"].status, "dismissed");
+    // Run again, still covering src/V.hs, but f1 is no longer reported at all.
+    const s2 = afterRun(s1, []);
+    assert.strictEqual(s2.findings["f1"].status, "dismissed");
+  });
+
+  it("re-opens a previously dismissed finding if it is re-reported without being re-dismissed", () => {
+    const s1 = afterRun(started(), [obs("f1")], ["f1"]);
+    assert.strictEqual(s1.findings["f1"].status, "dismissed");
+    // The run report re-observes f1, but the dismissals file no longer lists it:
+    // the dismissals file is the source of truth for each run, so f1 opens back up.
+    const s2 = afterRun(s1, [obs("f1")], []);
+    assert.strictEqual(s2.findings["f1"].status, "open");
+  });
+
+  it("fileEdited only stales open findings in the edited file", () => {
+    const s1 = afterRun(started(), [obs("f1"), obs("g1", "src/Other.hs")]);
+    // Manually drive f2 to fixed and f3 to dismissed within src/V.hs to check they aren't re-staled.
+    const withExtra = afterRun(s1, [obs("f1"), obs("f3", "src/V.hs", 9)], ["f3"]);
+    assert.strictEqual(withExtra.findings["f3"].status, "dismissed");
+    const s2 = reduceSession(withExtra, { type: "fileEdited", file: "src/V.hs" });
+    assert.strictEqual(s2.findings["f1"].status, "stale");
+    assert.strictEqual(s2.findings["f3"].status, "dismissed", "dismissed findings are not re-staled");
+    assert.strictEqual(s2.findings["g1"].status, "open", "findings in other files are untouched");
+  });
+
+  it("fileEdited does not re-stale an already-fixed finding", () => {
+    const s1 = afterRun(started(), [obs("f1")]);
+    const s2 = afterRun(s1, []); // f1 becomes fixed (no longer reported, but file still covered)
+    assert.strictEqual(s2.findings["f1"].status, "fixed");
+    const s3 = reduceSession(s2, { type: "fileEdited", file: "src/V.hs" });
+    assert.strictEqual(s3.findings["f1"].status, "fixed");
+  });
+
+  it("counts totals across a mixed state", () => {
+    const s1 = afterRun(started(), [obs("f1"), obs("f2", "src/V.hs", 7), obs("f3", "src/V.hs", 9)]);
+    const s2 = reduceSession(s1, { type: "findingDismissed", fingerprint: "f3" });
+    const s3 = reduceSession(s2, { type: "fileEdited", file: "src/V.hs" });
+    // f1, f2 -> stale (were open); f3 -> dismissed (unaffected by edit)
+    const s4 = afterRun(s3, [obs("f1")]); // f1 re-opens, f2 becomes fixed, f3 stays dismissed
+    const counts = countByStatus(s4);
+    assert.strictEqual(counts.open, 1);
+    assert.strictEqual(counts.fixed, 1);
+    assert.strictEqual(counts.dismissed, 1);
+    assert.strictEqual(counts.stale, 0);
+    assert.strictEqual(counts.open + counts.fixed + counts.dismissed + counts.stale, 3);
+  });
+
+  it("sessionStarted clears findings from a prior session", () => {
+    const s1 = afterRun(started(), [obs("f1")]);
+    assert.strictEqual(Object.keys(s1.findings).length, 1);
+    const s2 = reduceSession(s1, { type: "sessionStarted", startedAt: "2026-07-06T11:00:00Z" });
+    assert.strictEqual(Object.keys(s2.findings).length, 0);
+    assert.strictEqual(s2.phase, "active");
+    assert.strictEqual(s2.runCount, 0);
+  });
+});

--- a/vscode-plustan/src/core/sessionState.ts
+++ b/vscode-plustan/src/core/sessionState.ts
@@ -1,0 +1,98 @@
+import { ObservationV2 } from "./schema";
+
+export type FindingStatus = "open" | "stale" | "fixed" | "dismissed";
+
+export interface SessionFinding extends ObservationV2 {
+  status: FindingStatus;
+  lastSeenRun: number;
+}
+
+export interface SessionState {
+  phase: "idle" | "active";
+  startedAt: string | null;
+  runCount: number;
+  findings: Record<string, SessionFinding>;
+}
+
+export type SessionEvent =
+  | { type: "sessionStarted"; startedAt: string }
+  | { type: "runCompleted"; coveredFiles: string[]; observations: ObservationV2[]; dismissedFingerprints: string[] }
+  | { type: "fileEdited"; file: string }
+  | { type: "findingDismissed"; fingerprint: string }
+  | { type: "findingUndismissed"; fingerprint: string }
+  | { type: "sessionEnded" };
+
+export const initialSessionState: SessionState = {
+  phase: "idle",
+  startedAt: null,
+  runCount: 0,
+  findings: {}
+};
+
+export function reduceSession(state: SessionState, event: SessionEvent): SessionState {
+  switch (event.type) {
+    case "sessionStarted":
+      return { phase: "active", startedAt: event.startedAt, runCount: 0, findings: {} };
+
+    case "sessionEnded":
+      return { ...state, phase: "idle" };
+
+    case "runCompleted": {
+      const covered = new Set(event.coveredFiles);
+      const dismissed = new Set(event.dismissedFingerprints);
+      const runCount = state.runCount + 1;
+      const findings: Record<string, SessionFinding> = {};
+
+      // Carry forward everything in files this run did not cover.
+      for (const f of Object.values(state.findings)) {
+        if (!covered.has(f.file)) {
+          findings[f.fingerprint] = f;
+        }
+      }
+      // Everything reported by this run is open (or dismissed).
+      for (const o of event.observations) {
+        findings[o.fingerprint] = {
+          ...o,
+          status: dismissed.has(o.fingerprint) ? "dismissed" : "open",
+          lastSeenRun: runCount
+        };
+      }
+      // Previously-known findings in covered files that were NOT re-reported: fixed.
+      for (const f of Object.values(state.findings)) {
+        if (covered.has(f.file) && findings[f.fingerprint] === undefined) {
+          findings[f.fingerprint] =
+            f.status === "open" || f.status === "stale" ? { ...f, status: "fixed" } : f;
+        }
+      }
+      return { ...state, runCount, findings };
+    }
+
+    case "fileEdited": {
+      const findings = { ...state.findings };
+      for (const f of Object.values(findings)) {
+        if (f.file === event.file && f.status === "open") {
+          findings[f.fingerprint] = { ...f, status: "stale" };
+        }
+      }
+      return { ...state, findings };
+    }
+
+    case "findingDismissed":
+    case "findingUndismissed": {
+      const f = state.findings[event.fingerprint];
+      if (!f) {
+        return state;
+      }
+      const status: FindingStatus = event.type === "findingDismissed" ? "dismissed" : "open";
+      return { ...state, findings: { ...state.findings, [event.fingerprint]: { ...f, status } } };
+    }
+  }
+}
+
+export function countByStatus(state: SessionState): Record<FindingStatus, number> {
+  const counts: Record<FindingStatus, number> = { open: 0, stale: 0, fixed: 0, dismissed: 0 };
+  for (const f of Object.values(state.findings)) {
+    counts[f.status] += 1;
+  }
+  return counts;
+}

--- a/vscode-plustan/src/core/sessionState.ts
+++ b/vscode-plustan/src/core/sessionState.ts
@@ -16,11 +16,25 @@ export interface SessionState {
 
 export type SessionEvent =
   | { type: "sessionStarted"; startedAt: string }
+  // `dismissedFingerprints` is the COMPLETE source of truth for this run: the
+  // caller must pass the full current dismissal set every run, not a delta.
+  // A re-reported finding whose fingerprint is absent from this set will reopen.
+  // (This matches the design: the dismissals file is durable truth, read fresh
+  // each run.)
   | { type: "runCompleted"; coveredFiles: string[]; observations: ObservationV2[]; dismissedFingerprints: string[] }
   | { type: "fileEdited"; file: string }
   | { type: "findingDismissed"; fingerprint: string }
   | { type: "findingUndismissed"; fingerprint: string }
   | { type: "sessionEnded" };
+
+/**
+ * Compile-time exhaustiveness guard: adding a SessionEvent variant without
+ * handling it in reduceSession turns into a type error at the call to this
+ * helper (its argument is `never` only when every variant is handled).
+ */
+function assertNever(event: never): never {
+  throw new Error(`Unhandled SessionEvent: ${JSON.stringify(event)}`);
+}
 
 export const initialSessionState: SessionState = {
   phase: "idle",
@@ -86,6 +100,9 @@ export function reduceSession(state: SessionState, event: SessionEvent): Session
       const status: FindingStatus = event.type === "findingDismissed" ? "dismissed" : "open";
       return { ...state, findings: { ...state.findings, [event.fingerprint]: { ...f, status } } };
     }
+
+    default:
+      return assertNever(event);
   }
 }
 

--- a/vscode-plustan/src/core/sessionState.ts
+++ b/vscode-plustan/src/core/sessionState.ts
@@ -5,6 +5,7 @@ export type FindingStatus = "open" | "stale" | "fixed" | "dismissed";
 export interface SessionFinding extends ObservationV2 {
   status: FindingStatus;
   lastSeenRun: number;
+  dismissalNote?: string;
 }
 
 export interface SessionState {
@@ -21,9 +22,17 @@ export type SessionEvent =
   // A re-reported finding whose fingerprint is absent from this set will reopen.
   // (This matches the design: the dismissals file is durable truth, read fresh
   // each run.)
-  | { type: "runCompleted"; coveredFiles: string[]; observations: ObservationV2[]; dismissedFingerprints: string[] }
+  | {
+      type: "runCompleted";
+      coveredFiles: string[];
+      observations: ObservationV2[];
+      dismissedFingerprints: string[];
+      // fingerprint -> dismissal note, mirroring DismissalEntry.note. A plain
+      // Record (not the dismissals module type) keeps this file vscode-free.
+      dismissalNotes?: Record<string, string>;
+    }
   | { type: "fileEdited"; file: string }
-  | { type: "findingDismissed"; fingerprint: string }
+  | { type: "findingDismissed"; fingerprint: string; note?: string }
   | { type: "findingUndismissed"; fingerprint: string }
   | { type: "sessionEnded" };
 
@@ -65,10 +74,12 @@ export function reduceSession(state: SessionState, event: SessionEvent): Session
       }
       // Everything reported by this run is open (or dismissed).
       for (const o of event.observations) {
+        const isDismissed = dismissed.has(o.fingerprint);
         findings[o.fingerprint] = {
           ...o,
-          status: dismissed.has(o.fingerprint) ? "dismissed" : "open",
-          lastSeenRun: runCount
+          status: isDismissed ? "dismissed" : "open",
+          lastSeenRun: runCount,
+          dismissalNote: isDismissed ? event.dismissalNotes?.[o.fingerprint] : undefined
         };
       }
       // Previously-known findings in covered files that were NOT re-reported: fixed.
@@ -95,14 +106,26 @@ export function reduceSession(state: SessionState, event: SessionEvent): Session
       return changed ? { ...state, findings } : state;
     }
 
-    case "findingDismissed":
+    case "findingDismissed": {
+      const f = state.findings[event.fingerprint];
+      if (!f) {
+        return state;
+      }
+      return {
+        ...state,
+        findings: { ...state.findings, [event.fingerprint]: { ...f, status: "dismissed", dismissalNote: event.note } }
+      };
+    }
+
     case "findingUndismissed": {
       const f = state.findings[event.fingerprint];
       if (!f) {
         return state;
       }
-      const status: FindingStatus = event.type === "findingDismissed" ? "dismissed" : "open";
-      return { ...state, findings: { ...state.findings, [event.fingerprint]: { ...f, status } } };
+      return {
+        ...state,
+        findings: { ...state.findings, [event.fingerprint]: { ...f, status: "open", dismissalNote: undefined } }
+      };
     }
 
     default:

--- a/vscode-plustan/src/core/sessionState.ts
+++ b/vscode-plustan/src/core/sessionState.ts
@@ -82,13 +82,17 @@ export function reduceSession(state: SessionState, event: SessionEvent): Session
     }
 
     case "fileEdited": {
+      let changed = false;
       const findings = { ...state.findings };
-      for (const f of Object.values(findings)) {
+      for (const f of Object.values(state.findings)) {
         if (f.file === event.file && f.status === "open") {
           findings[f.fingerprint] = { ...f, status: "stale" };
+          changed = true;
         }
       }
-      return { ...state, findings };
+      // Return the SAME reference when nothing transitioned so callers can skip
+      // re-persisting/re-publishing on no-op edits (e.g. every keystroke).
+      return changed ? { ...state, findings } : state;
     }
 
     case "findingDismissed":

--- a/vscode-plustan/src/diagnostics.ts
+++ b/vscode-plustan/src/diagnostics.ts
@@ -1,0 +1,85 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { InspectionV2 } from "./core/schema";
+import { SessionFinding, SessionState } from "./core/sessionState";
+
+export interface PluStanDiagnostic extends vscode.Diagnostic {
+  plustanFingerprint?: string;
+  plustanInspectionId?: string;
+}
+
+export function publishSessionDiagnostics(
+  state: SessionState,
+  inspections: Map<string, InspectionV2>,
+  workspaceRoot: string,
+  collection: vscode.DiagnosticCollection
+): void {
+  collection.clear();
+  const byFile = new Map<string, PluStanDiagnostic[]>();
+
+  for (const finding of Object.values(state.findings)) {
+    if (finding.status !== "open" && finding.status !== "stale") {
+      continue;
+    }
+    const inspection = inspections.get(finding.inspectionId);
+    const filePath = path.isAbsolute(finding.file) ? finding.file : path.join(workspaceRoot, finding.file);
+    const stalePrefix = finding.status === "stale" ? "(stale) " : "";
+    const summary = inspection ? `${inspection.name} — ${inspection.description}` : "";
+    const diagnostic: PluStanDiagnostic = new vscode.Diagnostic(
+      toRange(finding),
+      `${stalePrefix}[${finding.inspectionId}] ${summary}`.trim(),
+      mapSeverity(inspection?.severity)
+    );
+    diagnostic.source = "plu-stan";
+    diagnostic.code = finding.inspectionId;
+    diagnostic.plustanFingerprint = finding.fingerprint;
+    diagnostic.plustanInspectionId = finding.inspectionId;
+    const list = byFile.get(filePath) ?? [];
+    list.push(diagnostic);
+    byFile.set(filePath, list);
+  }
+  collection.set([...byFile.entries()].map(([f, ds]) => [vscode.Uri.file(f), ds]));
+}
+
+export function toRange(finding: SessionFinding): vscode.Range {
+  const startLine = Math.max(0, finding.startLine - 1);
+  const startCharacter = Math.max(0, finding.startCol - 1);
+  const endLine = Math.max(startLine, finding.endLine - 1);
+  const rawEnd = Math.max(0, finding.endCol - 1);
+  const endCharacter = endLine === startLine ? Math.max(startCharacter + 1, rawEnd) : rawEnd;
+  return new vscode.Range(startLine, startCharacter, endLine, endCharacter);
+}
+
+function mapSeverity(severity: string | undefined): vscode.DiagnosticSeverity {
+  switch (severity) {
+    case "Error": return vscode.DiagnosticSeverity.Error;
+    case "Warning":
+    case "PotentialBug":
+    case "Performance": return vscode.DiagnosticSeverity.Warning;
+    default: return vscode.DiagnosticSeverity.Information;
+  }
+}
+
+export class DismissCodeActionProvider implements vscode.CodeActionProvider {
+  provideCodeActions(
+    _document: vscode.TextDocument,
+    _range: vscode.Range,
+    context: vscode.CodeActionContext
+  ): vscode.CodeAction[] {
+    const actions: vscode.CodeAction[] = [];
+    for (const diagnostic of context.diagnostics as PluStanDiagnostic[]) {
+      if (diagnostic.source !== "plu-stan" || !diagnostic.plustanFingerprint) {
+        continue;
+      }
+      const action = new vscode.CodeAction("Plu-Stan: Dismiss this finding", vscode.CodeActionKind.QuickFix);
+      action.diagnostics = [diagnostic];
+      action.command = {
+        command: "plustan.dismissFinding",
+        title: "Dismiss",
+        arguments: [{ fingerprint: diagnostic.plustanFingerprint, inspectionId: diagnostic.plustanInspectionId }]
+      };
+      actions.push(action);
+    }
+    return actions;
+  }
+}

--- a/vscode-plustan/src/extension.ts
+++ b/vscode-plustan/src/extension.ts
@@ -595,7 +595,10 @@ function getWorkspaceFolderOrNotify(): vscode.WorkspaceFolder | undefined {
 function readSettings(folder: vscode.WorkspaceFolder): PluStanSettings {
   const config = vscode.workspace.getConfiguration("plustan", folder.uri);
 
-  const binaryPath = config.get<string>("binaryPath", "").trim();
+  // VS Code does NOT expand `${workspaceFolder}` in arbitrary string settings
+  // (only in launch.json/tasks.json), so the extension expands it itself.
+  const rawBinaryPath = config.get<string>("binaryPath", "").trim();
+  const binaryPath = rawBinaryPath.replace("${workspaceFolder}", folder.uri.fsPath);
   const configuredProjectDir = config.get<string>("projectDir", "").trim();
   const projectDir = configuredProjectDir
     ? resolveAgainst(folder.uri.fsPath, configuredProjectDir)

--- a/vscode-plustan/src/extension.ts
+++ b/vscode-plustan/src/extension.ts
@@ -418,8 +418,10 @@ export function activate(context: vscode.ExtensionContext): void {
         const settings = await ensureBinaryConfigured(f, provider, resolveSettings);
         if (!settings) { return; }
         await controller.startReview(scopeArg);
-        // Reuse the listing startReview() already fetched — don't call listOnchain twice.
-        // Absent when the handshake failed or the user cancelled the module picker.
+        // Reuse the listing startReview() already fetched (captured before the
+        // module-scope picker, so it's the full set) — don't call listOnchain
+        // twice. Undefined only until a first successful handshake; once set it
+        // persists, so we populate the Onchain Modules view whenever we have it.
         if (controller.onchainListing) {
           provider.setData(controller.onchainListing.modules, controller.onchainListing.workspaceRoot);
         }

--- a/vscode-plustan/src/extension.ts
+++ b/vscode-plustan/src/extension.ts
@@ -185,6 +185,11 @@ export function activate(context: vscode.ExtensionContext): void {
     (line) => output.appendLine(line)
   );
 
+  // Assigned below once a workspace folder is resolved (inside `if (folder)`).
+  // The legacy one-shot commands read it to detect an active review session so
+  // they don't clobber the session's diagnostics; stays undefined with no folder.
+  let activeController: ReviewController | undefined;
+
   context.subscriptions.push(
     vscode.commands.registerCommand("plustan.openSettings", async () => {
       await vscode.commands.executeCommand("workbench.action.openSettings", "plustan.binaryPath");
@@ -221,6 +226,13 @@ export function activate(context: vscode.ExtensionContext): void {
   // auto-rerun on save (that is what "Start Review" is for now).
   context.subscriptions.push(
     vscode.commands.registerCommand("plustan.runWorkspace", async () => {
+      if (activeController?.sessionState.phase === "active") {
+        vscode.window.showInformationMessage(
+          "Plu-Stan: a review session is active — use the Findings view (or End Review first). " +
+          "Legacy one-shot analysis is disabled during a session."
+        );
+        return;
+      }
       if (!await saveWorkspaceBeforeRun()) {
         return;
       }
@@ -240,6 +252,13 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(
     vscode.commands.registerCommand("plustan.runModule", async (item?: OnchainModuleItem) => {
+      if (activeController?.sessionState.phase === "active") {
+        vscode.window.showInformationMessage(
+          "Plu-Stan: a review session is active — use the Findings view (or End Review first). " +
+          "Legacy one-shot analysis is disabled during a session."
+        );
+        return;
+      }
       if (!await saveWorkspaceBeforeRun()) {
         return;
       }
@@ -342,6 +361,10 @@ export function activate(context: vscode.ExtensionContext): void {
   })();
 
   if (folder) {
+    // Capture the resolved root once: `folder` is a const narrowed to defined
+    // here, but that narrowing is not carried into the hoisted openFinding
+    // function declaration below, so read the path eagerly.
+    const workspaceRoot = folder.uri.fsPath;
     const statusBar = new PluStanStatusBar();
     const findingsTree = new FindingsTreeProvider();
 
@@ -352,10 +375,12 @@ export function activate(context: vscode.ExtensionContext): void {
       context.workspaceState,
       (state, inspections) => {
         findingsTree.setData(state, inspections);
-        publishSessionDiagnostics(state, inspections, folder.uri.fsPath, diagnostics);
+        publishSessionDiagnostics(state, inspections, workspaceRoot, diagnostics);
       },
       output
     );
+    // Expose to the legacy one-shot commands so they can defer while a session runs.
+    activeController = controller;
 
     const detailPanel = new FindingDetailProvider(
       (finding) => { void controller.dismiss(finding.fingerprint, finding.inspectionId); },
@@ -365,8 +390,10 @@ export function activate(context: vscode.ExtensionContext): void {
     controller.restore();
 
     async function openFinding(finding: SessionFinding): Promise<void> {
-      const f = getWorkspaceFolder();
-      const filePath = path.isAbsolute(finding.file) ? finding.file : path.join(f.uri.fsPath, finding.file);
+      // Use the captured workspaceRoot (definite inside this block); re-deriving
+      // via getWorkspaceFolder() could throw, and this runs void-ed from the
+      // detail panel where a throw would become an unhandled rejection.
+      const filePath = path.isAbsolute(finding.file) ? finding.file : path.join(workspaceRoot, finding.file);
       const doc = await vscode.workspace.openTextDocument(filePath);
       const editor = await vscode.window.showTextDocument(doc, { preserveFocus: false });
       const range = toRange(finding);

--- a/vscode-plustan/src/extension.ts
+++ b/vscode-plustan/src/extension.ts
@@ -418,6 +418,11 @@ export function activate(context: vscode.ExtensionContext): void {
         const settings = await ensureBinaryConfigured(f, provider, resolveSettings);
         if (!settings) { return; }
         await controller.startReview(scopeArg);
+        // Reuse the listing startReview() already fetched — don't call listOnchain twice.
+        // Absent when the handshake failed or the user cancelled the module picker.
+        if (controller.onchainListing) {
+          provider.setData(controller.onchainListing.modules, controller.onchainListing.workspaceRoot);
+        }
       }),
       vscode.commands.registerCommand("plustan.endReview", () => controller.endReview()),
       vscode.commands.registerCommand("plustan.toggleFindingsGrouping", () => findingsTree.toggleGrouping()),

--- a/vscode-plustan/src/extension.ts
+++ b/vscode-plustan/src/extension.ts
@@ -1,57 +1,19 @@
 import * as path from "node:path";
-import { spawn } from "node:child_process";
 import * as vscode from "vscode";
 import { getCachedBinaryPath, offerDownload, checkForUpdates, detectProjectGhc } from "./downloadManager";
+import { SpawnAnalyzerClient, AnalyzerError } from "./analyzer/client";
+import { AnalyzePayloadV2, ListOnchainPayload, OnchainModule } from "./core/schema";
+import { ReviewController } from "./session/controller";
+import { DismissalsStore } from "./session/dismissalsStore";
+import { FindingsTreeProvider, FindingTreeItem } from "./ui/findingsTree";
+import { FindingDetailProvider } from "./ui/detailPanel";
+import { PluStanStatusBar } from "./ui/statusBar";
+import { DismissCodeActionProvider, publishSessionDiagnostics, toRange } from "./diagnostics";
+import { SessionFinding, initialSessionState, reduceSession } from "./core/sessionState";
 
 // Throttle for the background "newer backend available?" check on activation.
 const LAST_AUTO_UPDATE_CHECK_KEY = "plustan.lastAutoUpdateCheck";
 const AUTO_UPDATE_INTERVAL_MS = 24 * 60 * 60 * 1000; // once per day
-
-type AnnotationSource = "hi" | "source" | "both";
-type RunScope = "all" | "module";
-
-interface OnchainModule {
-  moduleName: string;
-  file: string;
-  annotationSource: AnnotationSource;
-}
-
-interface ListOnchainPayload {
-  version: number;
-  workspaceRoot: string;
-  hieDir: string;
-  modules: OnchainModule[];
-}
-
-interface Inspection {
-  id: string;
-  name: string;
-  severity: string;
-  description: string;
-}
-
-interface Observation {
-  id: string;
-  inspectionId: string;
-  file: string;
-  moduleName: string;
-  startLine: number;
-  startCol: number;
-  endLine: number;
-  endCol: number;
-}
-
-interface AnalysisSection {
-  observations: Observation[];
-}
-
-interface AnalyzePayload {
-  version: number;
-  runScope: RunScope;
-  targetModule: string | null;
-  inspections: Inspection[];
-  analysis: AnalysisSection;
-}
 
 interface PluStanSettings {
   binaryPath: string;
@@ -79,25 +41,6 @@ class OnchainModuleItem extends vscode.TreeItem {
   }
 }
 
-class ActionItem extends vscode.TreeItem {
-  constructor(
-    label: string,
-    description: string,
-    commandId: string,
-    title: string,
-    iconId: string
-  ) {
-    super(label, vscode.TreeItemCollapsibleState.None);
-    this.description = description;
-    this.contextValue = "plustanAction";
-    this.iconPath = new vscode.ThemeIcon(iconId);
-    this.command = {
-      command: commandId,
-      title
-    };
-  }
-}
-
 class MessageItem extends vscode.TreeItem {
   constructor(
     label: string,
@@ -115,7 +58,7 @@ class MessageItem extends vscode.TreeItem {
   }
 }
 
-type PluStanTreeItem = ActionItem | OnchainModuleItem | MessageItem;
+type PluStanTreeItem = OnchainModuleItem | MessageItem;
 
 class OnchainModulesProvider implements vscode.TreeDataProvider<PluStanTreeItem> {
   private modules: OnchainModule[] = [];
@@ -158,15 +101,10 @@ class OnchainModulesProvider implements vscode.TreeDataProvider<PluStanTreeItem>
       ]);
     }
 
-    const actionItems: ActionItem[] = [
-      new ActionItem("Run Workspace Analysis", "Run all onchain checks", "plustan.runWorkspace", "Run Workspace", "play-circle"),
-      new ActionItem("Refresh Onchain Modules", "Rescan module annotations", "plustan.refreshOnchainModules", "Refresh Onchain Modules", "refresh"),
-      new ActionItem("Clear Diagnostics", "Clear Problems panel entries", "plustan.clearDiagnostics", "Clear Diagnostics", "clear-all"),
-      new ActionItem("Show Plu-Stan Output", "Open extension output logs", "plustan.openOutput", "Show Output", "output")
-    ];
-
+    // Start/Run/Refresh/Clear now live in the Findings view title + command
+    // palette, so this view is just the discovered onchain modules.
     const moduleItems = this.modules.map((moduleInfo) => new OnchainModuleItem(moduleInfo, this.workspaceRoot));
-    return Promise.resolve([...actionItems, ...moduleItems]);
+    return Promise.resolve(moduleItems);
   }
 }
 
@@ -228,6 +166,25 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.window.registerTreeDataProvider("plustanOnchainModules", provider)
   );
 
+  // The analyzer client resolves its spawn config lazily (per call), so it is
+  // safe to construct even when no workspace folder is open — its getConfig
+  // throws only when actually invoked without a folder, and every command
+  // guards for that via getWorkspaceFolderOrNotify().
+  const client = new SpawnAnalyzerClient(
+    () => {
+      const f = getWorkspaceFolder();
+      const settings = resolveSettings(f);
+      return {
+        binaryPath: settings.binaryPath,
+        binaryPrefixArgs: [],
+        cwd: settings.projectDir,
+        hieDir: settings.hieDir,
+        extraArgs: settings.extraArgs
+      };
+    },
+    (line) => output.appendLine(line)
+  );
+
   context.subscriptions.push(
     vscode.commands.registerCommand("plustan.openSettings", async () => {
       await vscode.commands.executeCommand("workbench.action.openSettings", "plustan.binaryPath");
@@ -247,8 +204,8 @@ export function activate(context: vscode.ExtensionContext): void {
       if (!settings) {
         return;
       }
-      await withUserProgress("Refreshing onchain modules", async (token) => {
-        const payload = await runListOnchain(settings, output, token);
+      await withUserProgress("Refreshing onchain modules", async () => {
+        const payload = await client.listOnchain();
         appendOnchainModulesSummary(payload, folder, output);
         provider.setData(payload.modules, payload.workspaceRoot);
         vscode.window.setStatusBarMessage(
@@ -259,6 +216,9 @@ export function activate(context: vscode.ExtensionContext): void {
     })
   );
 
+  // Legacy one-shot analysis: run once, publish diagnostics via a throwaway
+  // SessionState, and stop. No review session is started and there is no
+  // auto-rerun on save (that is what "Start Review" is for now).
   context.subscriptions.push(
     vscode.commands.registerCommand("plustan.runWorkspace", async () => {
       if (!await saveWorkspaceBeforeRun()) {
@@ -273,13 +233,7 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
       await withUserProgress("Running Plu-Stan on workspace", async (token) => {
-        const payload = await runAnalyze(settings, output, token);
-        appendAnalyzeSummary(payload, folder, output);
-        publishDiagnostics(payload, folder, diagnostics);
-        vscode.window.setStatusBarMessage(
-          `Plu-Stan: ${payload.analysis.observations.length} observation(s)`,
-          3000
-        );
+        await runOneShot(client, { kind: "workspace" }, folder, diagnostics, output, token);
       });
     })
   );
@@ -298,17 +252,11 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
       await withUserProgress("Running Plu-Stan on module", async (token) => {
-        const moduleName = item?.moduleInfo.moduleName ?? (await pickModuleName(provider, settings, folder, output, token));
+        const moduleName = item?.moduleInfo.moduleName ?? (await pickModuleName(client, provider, folder));
         if (!moduleName) {
           return;
         }
-        const payload = await runAnalyze(settings, output, token, moduleName);
-        appendAnalyzeSummary(payload, folder, output);
-        publishDiagnostics(payload, folder, diagnostics);
-        vscode.window.setStatusBarMessage(
-          `Plu-Stan: ${moduleName} -> ${payload.analysis.observations.length} observation(s)`,
-          3000
-        );
+        await runOneShot(client, { kind: "module", moduleName }, folder, diagnostics, output, token, moduleName);
       });
     })
   );
@@ -385,9 +333,93 @@ export function activate(context: vscode.ExtensionContext): void {
   };
   context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(maybeRevealOnchainView));
 
+  // The review cockpit needs a definite workspace folder (DismissalsStore
+  // persists into it). Constructing it eagerly with a bogus folder would crash
+  // activation in the no-folder / single-loose-file case, so gate it here. The
+  // analyzer client and the legacy commands above stay available regardless.
+  const folder = ((): vscode.WorkspaceFolder | undefined => {
+    try { return getWorkspaceFolder(); } catch { return undefined; }
+  })();
+
+  if (folder) {
+    const statusBar = new PluStanStatusBar();
+    const findingsTree = new FindingsTreeProvider();
+
+    const controller = new ReviewController(
+      client,
+      new DismissalsStore(folder),
+      statusBar,
+      context.workspaceState,
+      (state, inspections) => {
+        findingsTree.setData(state, inspections);
+        publishSessionDiagnostics(state, inspections, folder.uri.fsPath, diagnostics);
+      },
+      output
+    );
+
+    const detailPanel = new FindingDetailProvider(
+      (finding) => { void controller.dismiss(finding.fingerprint, finding.inspectionId); },
+      (finding) => { void openFinding(finding); }
+    );
+
+    controller.restore();
+
+    async function openFinding(finding: SessionFinding): Promise<void> {
+      const f = getWorkspaceFolder();
+      const filePath = path.isAbsolute(finding.file) ? finding.file : path.join(f.uri.fsPath, finding.file);
+      const doc = await vscode.workspace.openTextDocument(filePath);
+      const editor = await vscode.window.showTextDocument(doc, { preserveFocus: false });
+      const range = toRange(finding);
+      editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+      editor.selection = new vscode.Selection(range.start, range.start);
+    }
+
+    context.subscriptions.push(
+      statusBar,
+      controller,
+      vscode.window.registerTreeDataProvider("plustanFindings", findingsTree),
+      vscode.window.registerWebviewViewProvider(FindingDetailProvider.viewId, detailPanel),
+      vscode.languages.registerCodeActionsProvider(
+        { language: "haskell", scheme: "file" },
+        new DismissCodeActionProvider(),
+        { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] }
+      ),
+      vscode.commands.registerCommand("plustan.startReview", async (scopeArg?: "all" | string[]) => {
+        if (!await saveWorkspaceBeforeRun()) { return; }
+        const f = getWorkspaceFolderOrNotify();
+        if (!f) { return; }
+        const settings = await ensureBinaryConfigured(f, provider, resolveSettings);
+        if (!settings) { return; }
+        await controller.startReview(scopeArg);
+      }),
+      vscode.commands.registerCommand("plustan.endReview", () => controller.endReview()),
+      vscode.commands.registerCommand("plustan.toggleFindingsGrouping", () => findingsTree.toggleGrouping()),
+      vscode.commands.registerCommand("plustan.openFinding", async (item?: FindingTreeItem) => {
+        if (!item) { return; }
+        detailPanel.showFinding(item.finding, controller.inspectionDocs.get(item.finding.inspectionId));
+        await openFinding(item.finding);
+      }),
+      vscode.commands.registerCommand("plustan.dismissFinding",
+        async (arg?: FindingTreeItem | { fingerprint: string; inspectionId: string }) => {
+          const target = arg instanceof FindingTreeItem
+            ? { fingerprint: arg.finding.fingerprint, inspectionId: arg.finding.inspectionId }
+            : arg;
+          if (!target) { return; }
+          const note = await vscode.window.showInputBox({
+            prompt: "Optional note: why is this finding not applicable?",
+            placeHolder: "e.g. credential-only comparison is intentional here"
+          });
+          await controller.dismiss(target.fingerprint, target.inspectionId, note || undefined);
+        }),
+      vscode.commands.registerCommand("plustan.undismissFinding", async (item?: FindingTreeItem) => {
+        if (item) { await controller.undismiss(item.finding.fingerprint); }
+      })
+    );
+  }
+
   try {
-    const folder = getWorkspaceFolder();
-    const configured = isEffectivelyConfigured(folder);
+    const activeFolder = getWorkspaceFolder();
+    const configured = isEffectivelyConfigured(activeFolder);
     provider.setBinaryConfigured(configured);
     if (configured) {
       // Already have a binary — quietly see if a newer backend shipped.
@@ -406,16 +438,63 @@ export function deactivate(): void {
   // no-op
 }
 
-async function pickModuleName(
-  provider: OnchainModulesProvider,
-  settings: PluStanSettings,
+/**
+ * Run a single analysis and publish its observations as diagnostics through a
+ * throwaway SessionState. No review session is started; this is the legacy
+ * one-shot path used by the Run Workspace / Run Module commands.
+ */
+async function runOneShot(
+  client: SpawnAnalyzerClient,
+  scope: { kind: "workspace" } | { kind: "module"; moduleName: string },
   folder: vscode.WorkspaceFolder,
+  diagnostics: vscode.DiagnosticCollection,
   output: vscode.OutputChannel,
-  token: vscode.CancellationToken
+  token: vscode.CancellationToken,
+  label?: string
+): Promise<void> {
+  const abort = new AbortController();
+  const sub = token.onCancellationRequested(() => abort.abort());
+  try {
+    const payload = await client.analyze(scope, abort.signal);
+    appendAnalyzeSummary(payload, folder, output);
+
+    const coveredFiles = [...new Set(payload.observations.map((o) => o.file))];
+    const oneShot = reduceSession(
+      reduceSession(initialSessionState, { type: "sessionStarted", startedAt: new Date().toISOString() }),
+      { type: "runCompleted", coveredFiles, observations: payload.observations, dismissedFingerprints: [] }
+    );
+    publishSessionDiagnostics(
+      oneShot,
+      new Map(payload.inspections.map((i) => [i.id, i])),
+      folder.uri.fsPath,
+      diagnostics
+    );
+
+    const prefix = label ? `${label} -> ` : "";
+    vscode.window.setStatusBarMessage(
+      `Plu-Stan: ${prefix}${payload.observations.length} observation(s)`,
+      3000
+    );
+  } catch (error) {
+    // A user-cancelled run is not a failure; withUserProgress would otherwise
+    // surface the AnalyzerError("cancelled") message as an error toast.
+    if (error instanceof AnalyzerError && error.kind === "cancelled") {
+      return;
+    }
+    throw error;
+  } finally {
+    sub.dispose();
+  }
+}
+
+async function pickModuleName(
+  client: SpawnAnalyzerClient,
+  provider: OnchainModulesProvider,
+  folder: vscode.WorkspaceFolder
 ): Promise<string | undefined> {
   let modules = provider.getData();
   if (modules.length === 0) {
-    const payload = await runListOnchain(settings, output, token);
+    const payload = await client.listOnchain();
     provider.setData(payload.modules, payload.workspaceRoot);
     modules = payload.modules;
   }
@@ -437,111 +516,6 @@ async function pickModuleName(
   );
 
   return pick?.label;
-}
-
-async function runListOnchain(
-  settings: PluStanSettings,
-  output: vscode.OutputChannel,
-  token: vscode.CancellationToken
-): Promise<ListOnchainPayload> {
-  const payload = await runPluStanJson<ListOnchainPayload>(
-    ["list-onchain", "--json", "--hiedir", settings.hieDir],
-    settings,
-    output,
-    token
-  );
-
-  if (!Array.isArray(payload.modules)) {
-    throw new Error("Invalid list-onchain payload: missing modules array");
-  }
-
-  return payload;
-}
-
-async function runAnalyze(
-  settings: PluStanSettings,
-  output: vscode.OutputChannel,
-  token: vscode.CancellationToken,
-  moduleName?: string
-): Promise<AnalyzePayload> {
-  const args = ["analyze", "--json", "--hiedir", settings.hieDir, ...settings.extraArgs];
-  if (moduleName) {
-    args.push("--module", moduleName);
-  }
-
-  const payload = await runPluStanJson<AnalyzePayload>(args, settings, output, token);
-  if (!payload.analysis || !Array.isArray(payload.analysis.observations)) {
-    throw new Error("Invalid analyze payload: missing analysis observations");
-  }
-
-  return payload;
-}
-
-function publishDiagnostics(
-  payload: AnalyzePayload,
-  folder: vscode.WorkspaceFolder,
-  diagnostics: vscode.DiagnosticCollection
-): void {
-  diagnostics.clear();
-
-  const inspections = new Map(payload.inspections.map((inspection) => [inspection.id, inspection]));
-  const diagnosticsByFile = new Map<string, vscode.Diagnostic[]>();
-
-  for (const observation of payload.analysis.observations) {
-    const inspection = inspections.get(observation.inspectionId);
-    const filePath = path.isAbsolute(observation.file)
-      ? observation.file
-      : path.join(folder.uri.fsPath, observation.file);
-
-    const message = inspection
-      ? `[${observation.inspectionId}] ${inspection.name}`
-      : `[${observation.inspectionId}]`;
-
-    const diagnostic = new vscode.Diagnostic(
-      toRange(observation),
-      message,
-      mapSeverity(inspection?.severity)
-    );
-    diagnostic.source = "plu-stan";
-    diagnostic.code = observation.inspectionId;
-
-    const fileDiagnostics = diagnosticsByFile.get(filePath) ?? [];
-    fileDiagnostics.push(diagnostic);
-    diagnosticsByFile.set(filePath, fileDiagnostics);
-  }
-
-  diagnostics.set(
-    [...diagnosticsByFile.entries()].map(([filePath, fileDiagnostics]) => [
-      vscode.Uri.file(filePath),
-      fileDiagnostics
-    ])
-  );
-}
-
-function toRange(observation: Observation): vscode.Range {
-  const startLine = Math.max(0, observation.startLine - 1);
-  const startCharacter = Math.max(0, observation.startCol - 1);
-  const endLine = Math.max(startLine, observation.endLine - 1);
-
-  const rawEndCharacter = Math.max(0, observation.endCol - 1);
-  const endCharacter = endLine === startLine
-    ? Math.max(startCharacter + 1, rawEndCharacter)
-    : rawEndCharacter;
-
-  return new vscode.Range(startLine, startCharacter, endLine, endCharacter);
-}
-
-function mapSeverity(severity: string | undefined): vscode.DiagnosticSeverity {
-  switch (severity) {
-    case "Error":
-      return vscode.DiagnosticSeverity.Error;
-    case "Warning":
-    case "PotentialBug":
-    case "Performance":
-      return vscode.DiagnosticSeverity.Warning;
-    default:
-      return vscode.DiagnosticSeverity.Information;
-  }
 }
 
 function getWorkspaceFolder(): vscode.WorkspaceFolder {
@@ -665,108 +639,6 @@ function toRelativePath(workspaceRoot: string, targetPath: string): string {
   return path.relative(workspaceRoot, absoluteTarget) || targetPath;
 }
 
-
-async function runPluStanJson<T>(
-  args: string[],
-  settings: PluStanSettings,
-  output: vscode.OutputChannel,
-  token: vscode.CancellationToken
-): Promise<T> {
-  if (settings.showOutputChannel) {
-    output.show(true);
-  }
-  output.appendLine(`$ ${settings.binaryPath} ${args.join(" ")}`);
-  output.appendLine(`cwd: ${settings.projectDir}`);
-
-  let stdout = "";
-  let stderr = "";
-  let exitCode = 0;
-  try {
-    const result = await spawnCommand(settings.binaryPath, args, settings.projectDir, output, token);
-    stdout = result.stdout;
-    stderr = result.stderr;
-    exitCode = result.exitCode;
-  } catch (error) {
-    if (isEnoentError(error)) {
-      throw new Error(
-        `Plu-Stan binary not found: ${settings.binaryPath}. ` +
-        "Set `plustan.binaryPath` to an existing executable."
-      );
-    }
-    throw error;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = parseJsonFromOutput(stdout);
-  } catch (error) {
-    // The binary produced no usable JSON. Before showing the raw parser error
-    // (which surfaces as the cryptic "Unexpected end of JSON input"), classify
-    // the failure so the message tells the user what to actually do. The most
-    // common cause is a GHC mismatch: stan reads .hie files whose format is
-    // locked to the exact GHC that built them, so a binary built with a
-    // different GHC panics and emits nothing on stdout.
-    output.appendLine(`Plu-Stan: stdout had no parseable JSON (exit ${exitCode}). Parser said: ${formatError(error)}`);
-    throw new Error(describePluStanFailure(stdout, stderr, exitCode));
-  }
-
-  if (exitCode !== 0) {
-    output.appendLine(`Plu-Stan exited with code ${exitCode}; using emitted JSON payload.`);
-  }
-
-  return parsed as T;
-}
-
-/** Turn a no-JSON plustan run into an actionable, user-facing message. */
-function describePluStanFailure(stdout: string, stderr: string, exitCode: number): string {
-  const haystack = `${stderr}\n${stdout}`;
-  const ghcMismatch = /hie file versions|readHieFile|built by a different ghc|different ghc/i.test(haystack);
-  const panicked = /panic!|the 'impossible' happened/i.test(haystack);
-
-  if (ghcMismatch) {
-    return (
-      "Plu-Stan couldn't read your project's .hie files: they were built with a different GHC " +
-      "than the plustan binary. Rebuild your project with the GHC the binary targets, or run " +
-      "\"Plu-Stan: Check for Updates\" to fetch a binary matching your project's GHC. " +
-      "(Full output is in the Plu-Stan output channel.)"
-    );
-  }
-
-  if (panicked) {
-    return (
-      `Plu-Stan crashed (exit ${exitCode}) and produced no analysis. ` +
-      "See the Plu-Stan output channel for the full crash log."
-    );
-  }
-
-  const noOutput = stdout.trim().length === 0;
-  return (
-    `Plu-Stan produced no JSON output (exit ${exitCode}). ` +
-    (noOutput
-      ? "The binary wrote nothing to stdout — it likely failed before analysis (e.g. an outdated or incompatible binary, or a build error). "
-      : "The output wasn't valid JSON. ") +
-    "See the Plu-Stan output channel for details; try \"Plu-Stan: Check for Updates\" if the binary may be outdated."
-  );
-}
-
-function parseJsonFromOutput(stdout: string): unknown {
-  const lines = stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
-
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    const line = lines[i];
-    try {
-      return JSON.parse(line);
-    } catch {
-      // Continue scanning earlier lines.
-    }
-  }
-
-  return JSON.parse(stdout);
-}
-
 function appendOnchainModulesSummary(
   payload: ListOnchainPayload,
   folder: vscode.WorkspaceFolder,
@@ -784,11 +656,11 @@ function appendOnchainModulesSummary(
 }
 
 function appendAnalyzeSummary(
-  payload: AnalyzePayload,
+  payload: AnalyzePayloadV2,
   folder: vscode.WorkspaceFolder,
   output: vscode.OutputChannel
 ): void {
-  const observations = payload.analysis.observations;
+  const observations = payload.observations;
   output.appendLine(
     `Plu-Stan analysis: runScope=${payload.runScope}, observations=${observations.length}`
   );
@@ -816,61 +688,6 @@ function appendAnalyzeSummary(
       `... truncated ${observations.length - maxLines} additional observation(s). See Problems panel for full list.`
     );
   }
-}
-
-function isEnoentError(error: unknown): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-  const maybeCode = (error as { code?: unknown }).code;
-  return maybeCode === "ENOENT";
-}
-
-function spawnCommand(
-  command: string,
-  args: string[],
-  cwd: string,
-  output: vscode.OutputChannel,
-  token: vscode.CancellationToken
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd,
-      env: process.env
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    const cancelSub = token.onCancellationRequested(() => {
-      child.kill("SIGTERM");
-    });
-
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString("utf8");
-    });
-
-    child.stderr.on("data", (chunk: Buffer) => {
-      const text = chunk.toString("utf8");
-      stderr += text;
-      output.append(text);
-    });
-
-    child.on("error", (error) => {
-      cancelSub.dispose();
-      const wrapped = new Error(`Failed to start plustan: ${formatError(error)}`) as Error & { code?: string };
-      const errorCode = (error as NodeJS.ErrnoException).code;
-      if (errorCode) {
-        wrapped.code = errorCode;
-      }
-      reject(wrapped);
-    });
-
-    child.on("close", (code) => {
-      cancelSub.dispose();
-      resolve({ stdout, stderr, exitCode: code ?? 1 });
-    });
-  });
 }
 
 async function withUserProgress(

--- a/vscode-plustan/src/session/controller.ts
+++ b/vscode-plustan/src/session/controller.ts
@@ -1,0 +1,257 @@
+import * as vscode from "vscode";
+import { AnalyzerClient, AnalyzerError, AnalyzeScope } from "../analyzer/client";
+import { InspectionV2, SchemaError } from "../core/schema";
+import { initialSessionState, reduceSession, SessionState } from "../core/sessionState";
+import { PendingRun, RunCoalescer } from "../core/runCoalescer";
+import { DismissalsStore } from "./dismissalsStore";
+import { PluStanStatusBar } from "../ui/statusBar";
+
+const SESSION_STORAGE_KEY = "plustan.session.v1";
+const SAVE_DEBOUNCE_MS = 500;
+
+interface PersistedSession {
+  state: SessionState;
+  inspections: [string, InspectionV2][];
+  moduleByFile: [string, string][];
+}
+
+export class ReviewController implements vscode.Disposable {
+  private state: SessionState = initialSessionState;
+  private inspections = new Map<string, InspectionV2>();
+  private moduleByFile = new Map<string, string>(); // file path → module name
+  private readonly queue = new RunCoalescer();
+  private running = false;
+  private buildFailed = false;
+  private debounceTimer: NodeJS.Timeout | undefined;
+  private abort: AbortController | undefined;
+  private readonly disposables: vscode.Disposable[] = [];
+
+  constructor(
+    private readonly client: AnalyzerClient,
+    private readonly dismissals: DismissalsStore,
+    private readonly statusBar: PluStanStatusBar,
+    private readonly workspaceState: vscode.Memento,
+    private readonly onStateChange: (state: SessionState, inspections: Map<string, InspectionV2>) => void,
+    private readonly output: vscode.OutputChannel
+  ) {
+    this.disposables.push(
+      vscode.workspace.onDidSaveTextDocument((doc) => this.handleSave(doc)),
+      // A finding is stale as soon as its file is *edited*, not only once saved.
+      vscode.workspace.onDidChangeTextDocument((e) => {
+        if (this.state.phase === "active" && e.contentChanges.length > 0) {
+          const file = this.fileKeyForDocument(e.document);
+          if (this.moduleForDocument(e.document)) {
+            this.dispatch({ type: "fileEdited", file });
+          }
+        }
+      })
+    );
+  }
+
+  get sessionState(): SessionState { return this.state; }
+  get inspectionDocs(): Map<string, InspectionV2> { return this.inspections; }
+
+  restore(): void {
+    const saved = this.workspaceState.get<PersistedSession>(SESSION_STORAGE_KEY);
+    if (saved && saved.state.phase === "active") {
+      this.state = saved.state;
+      this.inspections = new Map(saved.inspections);
+      this.moduleByFile = new Map(saved.moduleByFile);
+      void vscode.commands.executeCommand("setContext", "plustan.sessionActive", true);
+      this.publish();
+    }
+  }
+
+  /**
+   * Start a review. Scope: the whole workspace or a chosen set of onchain
+   * modules. scopeArg === "all" (or ≤1 module) skips the picker — used
+   * programmatically and by the integration test.
+   */
+  async startReview(scopeArg?: "all" | string[]): Promise<void> {
+    let moduleByFile: Map<string, string>;
+    try {
+      await this.client.capabilities();
+      const list = await this.client.listOnchain();
+      moduleByFile = new Map(list.modules.map((m) => [m.file, m.moduleName]));
+    } catch (error) {
+      await this.explainStartFailure(error);
+      return;
+    }
+
+    if (scopeArg === undefined && moduleByFile.size > 1) {
+      const picks = await vscode.window.showQuickPick(
+        [...moduleByFile.values()].sort().map((moduleName) => ({ label: moduleName, picked: true })),
+        { canPickMany: true, placeHolder: "Modules to review (all preselected)" }
+      );
+      if (!picks) {
+        return; // user cancelled
+      }
+      scopeArg = picks.map((p) => p.label);
+    }
+    if (Array.isArray(scopeArg)) {
+      const wanted = new Set(scopeArg);
+      moduleByFile = new Map([...moduleByFile.entries()].filter(([, m]) => wanted.has(m)));
+    }
+    this.moduleByFile = moduleByFile;
+
+    this.dispatch({ type: "sessionStarted", startedAt: new Date().toISOString() });
+    await vscode.commands.executeCommand("setContext", "plustan.sessionActive", true);
+    this.queue.request({ kind: "workspace" });
+    void this.pump();
+  }
+
+  async endReview(): Promise<void> {
+    this.dispatch({ type: "sessionEnded" });
+    await vscode.commands.executeCommand("setContext", "plustan.sessionActive", false);
+    this.abort?.abort();
+    const c = this.state.findings;
+    this.output.appendLine(
+      `Plu-Stan review ended: ${Object.values(c).filter((f) => f.status === "fixed").length} fixed, ` +
+      `${Object.values(c).filter((f) => f.status === "open" || f.status === "stale").length} open, ` +
+      `${Object.values(c).filter((f) => f.status === "dismissed").length} dismissed.`
+    );
+  }
+
+  async dismiss(fingerprint: string, inspectionId: string, note?: string): Promise<void> {
+    await this.dismissals.add({ fingerprint, inspectionId, note, dismissedAt: new Date().toISOString() });
+    this.dispatch({ type: "findingDismissed", fingerprint });
+  }
+
+  async undismiss(fingerprint: string): Promise<void> {
+    await this.dismissals.remove(fingerprint);
+    this.dispatch({ type: "findingUndismissed", fingerprint });
+  }
+
+  private handleSave(doc: vscode.TextDocument): void {
+    if (this.state.phase !== "active") {
+      return;
+    }
+    const moduleName = this.moduleForDocument(doc);
+    if (!moduleName) {
+      return;
+    }
+    this.dispatch({ type: "fileEdited", file: this.fileKeyForDocument(doc) });
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.queue.request({ kind: "module", moduleName });
+      void this.pump();
+    }, SAVE_DEBOUNCE_MS);
+  }
+
+  /** The backend reports workspace-relative paths; match on suffix. */
+  private moduleForDocument(doc: vscode.TextDocument): string | undefined {
+    for (const [file, moduleName] of this.moduleByFile) {
+      if (doc.fileName.endsWith(file)) {
+        return moduleName;
+      }
+    }
+    return undefined;
+  }
+
+  private fileKeyForDocument(doc: vscode.TextDocument): string {
+    for (const [file] of this.moduleByFile) {
+      if (doc.fileName.endsWith(file)) {
+        return file;
+      }
+    }
+    return doc.fileName;
+  }
+
+  private async pump(): Promise<void> {
+    if (this.running) {
+      return;
+    }
+    const next = this.queue.takeNext();
+    if (!next) {
+      return;
+    }
+    this.running = true;
+    this.publish();
+    try {
+      await this.runOne(next);
+      this.buildFailed = false;
+    } catch (error) {
+      if (error instanceof AnalyzerError && error.kind === "cancelled") {
+        // A newer save superseded this run; not a failure — stay quiet.
+      } else if (error instanceof AnalyzerError && error.kind === "build-failed") {
+        this.buildFailed = true; // keep findings; status bar explains; next save retries
+        this.output.appendLine(error.message);
+      } else {
+        this.output.appendLine(`Plu-Stan run failed: ${error instanceof Error ? error.message : String(error)}`);
+        void vscode.window.showErrorMessage(`Plu-Stan: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    } finally {
+      this.running = false;
+      this.publish();
+      if (this.queue.size > 0) {
+        void this.pump();
+      }
+    }
+  }
+
+  private async runOne(run: PendingRun): Promise<void> {
+    this.abort = new AbortController();
+    const scope: AnalyzeScope = run.kind === "workspace"
+      ? { kind: "workspace" }
+      : { kind: "module", moduleName: run.moduleName };
+    const payload = await this.client.analyze(scope, this.abort.signal);
+
+    for (const inspection of payload.inspections) {
+      this.inspections.set(inspection.id, inspection);
+    }
+    const coveredFiles = run.kind === "workspace"
+      ? [...this.moduleByFile.keys()]
+      : [...this.moduleByFile.entries()].filter(([, m]) => m === run.moduleName).map(([f]) => f);
+    // A module-scoped session still gets whole-project observations from a
+    // workspace-kind run — keep only files inside the session scope.
+    const covered = new Set(coveredFiles);
+    const observations = payload.observations.filter((o) => covered.has(o.file));
+    const dismissed = (await this.dismissals.load()).dismissals.map((d) => d.fingerprint);
+    this.dispatch({
+      type: "runCompleted",
+      coveredFiles,
+      observations,
+      dismissedFingerprints: dismissed
+    });
+  }
+
+  private dispatch(event: Parameters<typeof reduceSession>[1]): void {
+    this.state = reduceSession(this.state, event);
+    void this.workspaceState.update(SESSION_STORAGE_KEY, {
+      state: this.state,
+      inspections: [...this.inspections.entries()],
+      moduleByFile: [...this.moduleByFile.entries()]
+    } satisfies PersistedSession);
+    this.publish();
+  }
+
+  private publish(): void {
+    this.statusBar.update(this.state, this.running, this.buildFailed);
+    this.onStateChange(this.state, this.inspections);
+  }
+
+  private async explainStartFailure(error: unknown): Promise<void> {
+    if (error instanceof AnalyzerError && error.kind === "cancelled") {
+      return; // start aborted; nothing to explain
+    }
+    const message = error instanceof SchemaError || error instanceof AnalyzerError
+      ? error.message
+      : `Plu-Stan handshake failed: ${error instanceof Error ? error.message : String(error)}`;
+    const choice = await vscode.window.showErrorMessage(message, "Check for Updates");
+    if (choice === "Check for Updates") {
+      await vscode.commands.executeCommand("plustan.checkForUpdates");
+    }
+  }
+
+  dispose(): void {
+    this.abort?.abort();
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    for (const d of this.disposables) {
+      d.dispose();
+    }
+  }
+}

--- a/vscode-plustan/src/session/controller.ts
+++ b/vscode-plustan/src/session/controller.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { AnalyzerClient, AnalyzerError, AnalyzeScope } from "../analyzer/client";
-import { InspectionV2, SchemaError } from "../core/schema";
+import { InspectionV2, ListOnchainPayload, SchemaError } from "../core/schema";
 import { initialSessionState, reduceSession, SessionState } from "../core/sessionState";
 import { PendingRun, RunCoalescer } from "../core/runCoalescer";
 import { DismissalsStore } from "./dismissalsStore";
@@ -26,6 +26,7 @@ export class ReviewController implements vscode.Disposable {
   // window must schedule TWO runs, not let B's reset cancel A's pending run.
   private readonly debounceTimers = new Map<string, NodeJS.Timeout>();
   private abort: AbortController | undefined;
+  private lastListing?: ListOnchainPayload;
   private readonly disposables: vscode.Disposable[] = [];
 
   constructor(
@@ -49,6 +50,8 @@ export class ReviewController implements vscode.Disposable {
 
   get sessionState(): SessionState { return this.state; }
   get inspectionDocs(): Map<string, InspectionV2> { return this.inspections; }
+  /** The onchain module listing fetched by the most recent successful startReview(), if any. */
+  get onchainListing(): ListOnchainPayload | undefined { return this.lastListing; }
 
   restore(): void {
     const saved = this.workspaceState.get<PersistedSession>(SESSION_STORAGE_KEY);
@@ -71,6 +74,7 @@ export class ReviewController implements vscode.Disposable {
     try {
       await this.client.capabilities();
       const list = await this.client.listOnchain();
+      this.lastListing = list;
       moduleByFile = new Map(list.modules.map((m) => [m.file, m.moduleName]));
     } catch (error) {
       await this.explainStartFailure(error);

--- a/vscode-plustan/src/session/controller.ts
+++ b/vscode-plustan/src/session/controller.ts
@@ -116,7 +116,7 @@ export class ReviewController implements vscode.Disposable {
 
   async dismiss(fingerprint: string, inspectionId: string, note?: string): Promise<void> {
     await this.dismissals.add({ fingerprint, inspectionId, note, dismissedAt: new Date().toISOString() });
-    this.dispatch({ type: "findingDismissed", fingerprint });
+    this.dispatch({ type: "findingDismissed", fingerprint, note });
   }
 
   async undismiss(fingerprint: string): Promise<void> {
@@ -231,7 +231,14 @@ export class ReviewController implements vscode.Disposable {
     // workspace-kind run — keep only files inside the session scope.
     const covered = new Set(coveredFiles);
     const observations = payload.observations.filter((o) => covered.has(o.file));
-    const dismissed = (await this.dismissals.load()).dismissals.map((d) => d.fingerprint);
+    const dismissalEntries = (await this.dismissals.load()).dismissals;
+    const dismissed = dismissalEntries.map((d) => d.fingerprint);
+    const dismissalNotes: Record<string, string> = {};
+    for (const entry of dismissalEntries) {
+      if (entry.note) {
+        dismissalNotes[entry.fingerprint] = entry.note;
+      }
+    }
     // Defense-in-depth: if the session ended while this run was in flight, don't
     // dispatch runCompleted against the now-idle state.
     if (this.state.phase !== "active") {
@@ -241,7 +248,8 @@ export class ReviewController implements vscode.Disposable {
       type: "runCompleted",
       coveredFiles,
       observations,
-      dismissedFingerprints: dismissed
+      dismissedFingerprints: dismissed,
+      dismissalNotes
     });
   }
 

--- a/vscode-plustan/src/session/controller.ts
+++ b/vscode-plustan/src/session/controller.ts
@@ -72,10 +72,18 @@ export class ReviewController implements vscode.Disposable {
   async startReview(scopeArg?: "all" | string[]): Promise<void> {
     let moduleByFile: Map<string, string>;
     try {
-      await this.client.capabilities();
-      const list = await this.client.listOnchain();
-      this.lastListing = list;
-      moduleByFile = new Map(list.modules.map((m) => [m.file, m.moduleName]));
+      // Discovery (handshake + list-onchain) can be the slowest step on a cold
+      // start because list-onchain triggers a .hie build — show a progress bar
+      // in the Findings view so the click doesn't feel unresponsive.
+      moduleByFile = await vscode.window.withProgress(
+        { location: { viewId: "plustanFindings" }, title: "Plu-Stan: discovering onchain modules…" },
+        async () => {
+          await this.client.capabilities();
+          const list = await this.client.listOnchain();
+          this.lastListing = list;
+          return new Map(list.modules.map((m) => [m.file, m.moduleName]));
+        }
+      );
     } catch (error) {
       await this.explainStartFailure(error);
       return;
@@ -197,7 +205,13 @@ export class ReviewController implements vscode.Disposable {
     this.running = true;
     this.publish();
     try {
-      await this.runOne(next);
+      const title = next.kind === "workspace"
+        ? "Plu-Stan: analyzing workspace…"
+        : `Plu-Stan: analyzing ${next.moduleName}…`;
+      await vscode.window.withProgress(
+        { location: { viewId: "plustanFindings" }, title },
+        () => this.runOne(next)
+      );
       this.buildFailed = false;
     } catch (error) {
       if (error instanceof AnalyzerError && error.kind === "cancelled") {

--- a/vscode-plustan/src/session/controller.ts
+++ b/vscode-plustan/src/session/controller.ts
@@ -22,7 +22,9 @@ export class ReviewController implements vscode.Disposable {
   private readonly queue = new RunCoalescer();
   private running = false;
   private buildFailed = false;
-  private debounceTimer: NodeJS.Timeout | undefined;
+  // One debounce timer per module: saving module A then module B within the
+  // window must schedule TWO runs, not let B's reset cancel A's pending run.
+  private readonly debounceTimers = new Map<string, NodeJS.Timeout>();
   private abort: AbortController | undefined;
   private readonly disposables: vscode.Disposable[] = [];
 
@@ -38,11 +40,8 @@ export class ReviewController implements vscode.Disposable {
       vscode.workspace.onDidSaveTextDocument((doc) => this.handleSave(doc)),
       // A finding is stale as soon as its file is *edited*, not only once saved.
       vscode.workspace.onDidChangeTextDocument((e) => {
-        if (this.state.phase === "active" && e.contentChanges.length > 0) {
-          const file = this.fileKeyForDocument(e.document);
-          if (this.moduleForDocument(e.document)) {
-            this.dispatch({ type: "fileEdited", file });
-          }
+        if (this.state.phase === "active" && e.contentChanges.length > 0 && this.moduleForDocument(e.document)) {
+          this.dispatch({ type: "fileEdited", file: this.fileKeyForDocument(e.document) });
         }
       })
     );
@@ -103,7 +102,10 @@ export class ReviewController implements vscode.Disposable {
   async endReview(): Promise<void> {
     this.dispatch({ type: "sessionEnded" });
     await vscode.commands.executeCommand("setContext", "plustan.sessionActive", false);
+    // Cancel the in-flight run AND any pending debounced runs, so no callback
+    // later builds a fresh run and dispatches runCompleted against the idle state.
     this.abort?.abort();
+    this.clearDebounceTimers();
     const c = this.state.findings;
     this.output.appendLine(
       `Plu-Stan review ended: ${Object.values(c).filter((f) => f.status === "fixed").length} fixed, ` +
@@ -131,19 +133,31 @@ export class ReviewController implements vscode.Disposable {
       return;
     }
     this.dispatch({ type: "fileEdited", file: this.fileKeyForDocument(doc) });
-    if (this.debounceTimer) {
-      clearTimeout(this.debounceTimer);
+    const existing = this.debounceTimers.get(moduleName);
+    if (existing) {
+      clearTimeout(existing);
     }
-    this.debounceTimer = setTimeout(() => {
-      this.queue.request({ kind: "module", moduleName });
-      void this.pump();
-    }, SAVE_DEBOUNCE_MS);
+    this.debounceTimers.set(
+      moduleName,
+      setTimeout(() => {
+        this.debounceTimers.delete(moduleName);
+        this.queue.request({ kind: "module", moduleName });
+        void this.pump();
+      }, SAVE_DEBOUNCE_MS)
+    );
+  }
+
+  private clearDebounceTimers(): void {
+    for (const timer of this.debounceTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.debounceTimers.clear();
   }
 
   /** The backend reports workspace-relative paths; match on suffix. */
   private moduleForDocument(doc: vscode.TextDocument): string | undefined {
     for (const [file, moduleName] of this.moduleByFile) {
-      if (doc.fileName.endsWith(file)) {
+      if (this.pathEndsWith(doc.fileName, file)) {
         return moduleName;
       }
     }
@@ -152,11 +166,20 @@ export class ReviewController implements vscode.Disposable {
 
   private fileKeyForDocument(doc: vscode.TextDocument): string {
     for (const [file] of this.moduleByFile) {
-      if (doc.fileName.endsWith(file)) {
+      if (this.pathEndsWith(doc.fileName, file)) {
         return file;
       }
     }
     return doc.fileName;
+  }
+
+  /**
+   * Suffix match on a path boundary only: "src/MyV.hs" must NOT match the
+   * relative path "V.hs". The backend reports forward-slash relative paths,
+   * so a POSIX "/" boundary check is sufficient.
+   */
+  private pathEndsWith(full: string, suffix: string): boolean {
+    return full === suffix || full.endsWith((suffix.startsWith("/") ? "" : "/") + suffix);
   }
 
   private async pump(): Promise<void> {
@@ -174,7 +197,7 @@ export class ReviewController implements vscode.Disposable {
       this.buildFailed = false;
     } catch (error) {
       if (error instanceof AnalyzerError && error.kind === "cancelled") {
-        // A newer save superseded this run; not a failure — stay quiet.
+        // endReview/dispose aborted this run; not a failure — stay quiet.
       } else if (error instanceof AnalyzerError && error.kind === "build-failed") {
         this.buildFailed = true; // keep findings; status bar explains; next save retries
         this.output.appendLine(error.message);
@@ -209,6 +232,11 @@ export class ReviewController implements vscode.Disposable {
     const covered = new Set(coveredFiles);
     const observations = payload.observations.filter((o) => covered.has(o.file));
     const dismissed = (await this.dismissals.load()).dismissals.map((d) => d.fingerprint);
+    // Defense-in-depth: if the session ended while this run was in flight, don't
+    // dispatch runCompleted against the now-idle state.
+    if (this.state.phase !== "active") {
+      return;
+    }
     this.dispatch({
       type: "runCompleted",
       coveredFiles,
@@ -218,7 +246,14 @@ export class ReviewController implements vscode.Disposable {
   }
 
   private dispatch(event: Parameters<typeof reduceSession>[1]): void {
-    this.state = reduceSession(this.state, event);
+    const next = reduceSession(this.state, event);
+    // A no-op edit (e.g. a keystroke in a file with no open finding) leaves the
+    // reference unchanged: skip the Memento write and republish to avoid
+    // per-keystroke write amplification.
+    if (next === this.state) {
+      return;
+    }
+    this.state = next;
     void this.workspaceState.update(SESSION_STORAGE_KEY, {
       state: this.state,
       inspections: [...this.inspections.entries()],
@@ -247,9 +282,7 @@ export class ReviewController implements vscode.Disposable {
 
   dispose(): void {
     this.abort?.abort();
-    if (this.debounceTimer) {
-      clearTimeout(this.debounceTimer);
-    }
+    this.clearDebounceTimers();
     for (const d of this.disposables) {
       d.dispose();
     }

--- a/vscode-plustan/src/session/dismissalsStore.ts
+++ b/vscode-plustan/src/session/dismissalsStore.ts
@@ -4,6 +4,12 @@ import { DismissalEntry, DismissalsFile, addDismissal, emptyDismissals, parseDis
 const FILE_PATH = ".plustan/dismissals.json";
 
 export class DismissalsStore {
+  // Serializes mutations: each add/remove chains off the previous one so two
+  // overlapping load-modify-write cycles can't clobber each other. The tail is
+  // always kept in a resolved state (see `enqueue`) so a failed op never
+  // poisons the chain and blocks later writes.
+  private queue: Promise<unknown> = Promise.resolve();
+
   constructor(private readonly folder: vscode.WorkspaceFolder) {}
 
   private get uri(): vscode.Uri {
@@ -14,19 +20,43 @@ export class DismissalsStore {
     try {
       const bytes = await vscode.workspace.fs.readFile(this.uri);
       return parseDismissals(Buffer.from(bytes).toString("utf8"));
-    } catch {
-      return emptyDismissals(); // file absent
+    } catch (err) {
+      // A missing file is the normal "no dismissals yet" case. Anything else
+      // (permissions, transient I/O, path-is-a-directory) must propagate so
+      // callers never trigger a save that overwrites an existing-but-unreadable
+      // file and wipes real dismissals.
+      if (err instanceof vscode.FileSystemError && err.code === "FileNotFound") {
+        return emptyDismissals();
+      }
+      throw err;
     }
   }
 
-  async add(entry: DismissalEntry): Promise<DismissalsFile> {
-    const next = addDismissal(await this.load(), entry);
-    await this.save(next);
-    return next;
+  add(entry: DismissalEntry): Promise<DismissalsFile> {
+    return this.enqueue(() => this.mutate((file) => addDismissal(file, entry)));
   }
 
-  async remove(fingerprint: string): Promise<DismissalsFile> {
-    const next = removeDismissal(await this.load(), fingerprint);
+  remove(fingerprint: string): Promise<DismissalsFile> {
+    return this.enqueue(() => this.mutate((file) => removeDismissal(file, fingerprint)));
+  }
+
+  /**
+   * Runs `op` after all previously enqueued ops have settled. The caller gets
+   * the real result (or rejection) of their own op via the returned promise,
+   * while the chain tail is sanitized to always resolve so a rejection here
+   * cannot stall subsequent writes.
+   */
+  private enqueue<T>(op: () => Promise<T>): Promise<T> {
+    const run = this.queue.then(() => op());
+    this.queue = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
+  private async mutate(apply: (file: DismissalsFile) => DismissalsFile): Promise<DismissalsFile> {
+    const next = apply(await this.load());
     await this.save(next);
     return next;
   }

--- a/vscode-plustan/src/session/dismissalsStore.ts
+++ b/vscode-plustan/src/session/dismissalsStore.ts
@@ -1,0 +1,38 @@
+import * as vscode from "vscode";
+import { DismissalEntry, DismissalsFile, addDismissal, emptyDismissals, parseDismissals, removeDismissal, serializeDismissals } from "../core/dismissals";
+
+const FILE_PATH = ".plustan/dismissals.json";
+
+export class DismissalsStore {
+  constructor(private readonly folder: vscode.WorkspaceFolder) {}
+
+  private get uri(): vscode.Uri {
+    return vscode.Uri.joinPath(this.folder.uri, FILE_PATH);
+  }
+
+  async load(): Promise<DismissalsFile> {
+    try {
+      const bytes = await vscode.workspace.fs.readFile(this.uri);
+      return parseDismissals(Buffer.from(bytes).toString("utf8"));
+    } catch {
+      return emptyDismissals(); // file absent
+    }
+  }
+
+  async add(entry: DismissalEntry): Promise<DismissalsFile> {
+    const next = addDismissal(await this.load(), entry);
+    await this.save(next);
+    return next;
+  }
+
+  async remove(fingerprint: string): Promise<DismissalsFile> {
+    const next = removeDismissal(await this.load(), fingerprint);
+    await this.save(next);
+    return next;
+  }
+
+  private async save(file: DismissalsFile): Promise<void> {
+    await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(this.folder.uri, ".plustan"));
+    await vscode.workspace.fs.writeFile(this.uri, Buffer.from(serializeDismissals(file), "utf8"));
+  }
+}

--- a/vscode-plustan/src/test/runTest.ts
+++ b/vscode-plustan/src/test/runTest.ts
@@ -1,0 +1,26 @@
+import * as path from "node:path";
+import { runTests } from "@vscode/test-electron";
+
+// Some dev shells (e.g. tooling that itself runs on Electron) leak
+// ELECTRON_RUN_AS_NODE=1 into the environment. If that survives into the
+// spawned VS Code process, its Electron binary runs as a plain Node CLI
+// instead of launching the app — @vscode/test-electron then fails with a
+// confusing "Cannot find module '<workspace path>'" error. Strip it before
+// handing off so the child always launches as a real VS Code instance.
+delete process.env.ELECTRON_RUN_AS_NODE;
+
+async function main(): Promise<void> {
+  const extensionDevelopmentPath = path.resolve(__dirname, "..", "..");
+  const extensionTestsPath = path.resolve(__dirname, "suite", "index");
+  const workspace = path.resolve(extensionDevelopmentPath, "test-fixtures", "workspace");
+  await runTests({
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs: [workspace, "--disable-extensions"]
+  });
+}
+
+main().catch((err) => {
+  console.error("Integration tests failed:", err);
+  process.exit(1);
+});

--- a/vscode-plustan/src/test/suite/index.ts
+++ b/vscode-plustan/src/test/suite/index.ts
@@ -1,0 +1,11 @@
+import * as path from "node:path";
+// require-form import: works regardless of the tsconfig's esModuleInterop setting
+import Mocha = require("mocha");
+
+export function run(): Promise<void> {
+  const mocha = new Mocha({ ui: "bdd", timeout: 60_000, color: true });
+  mocha.addFile(path.resolve(__dirname, "session.test.js"));
+  return new Promise((resolve, reject) => {
+    mocha.run((failures) => (failures > 0 ? reject(new Error(`${failures} tests failed`)) : resolve()));
+  });
+}

--- a/vscode-plustan/src/test/suite/session.test.ts
+++ b/vscode-plustan/src/test/suite/session.test.ts
@@ -1,0 +1,31 @@
+import * as assert from "node:assert";
+import * as vscode from "vscode";
+
+async function poll<T>(fn: () => T | undefined, timeoutMs = 30_000): Promise<T> {
+  const start = Date.now();
+  for (;;) {
+    const value = fn();
+    if (value !== undefined) {
+      return value;
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("poll timed out");
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+}
+
+describe("review session (integration)", () => {
+  it("start review produces diagnostics from the stub binary", async () => {
+    // "all" skips the module-scope QuickPick (which would block a headless test)
+    await vscode.commands.executeCommand("plustan.startReview", "all");
+    const diags = await poll(() => {
+      const all = vscode.languages.getDiagnostics()
+        .flatMap(([, ds]) => ds)
+        .filter((d) => d.source === "plu-stan");
+      return all.length >= 2 ? all : undefined;
+    });
+    assert.strictEqual(diags.length, 2);
+    assert.ok(diags[0].message.includes("PLU-STAN-04"));
+  });
+});

--- a/vscode-plustan/src/ui/detailPanel.ts
+++ b/vscode-plustan/src/ui/detailPanel.ts
@@ -93,10 +93,23 @@ function wrap(body: string): string {
   return `<!DOCTYPE html><html><head><meta charset="UTF-8">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
     <style>
-      body { font-family: var(--vscode-font-family); font-size: 13px; padding: 8px; }
-      pre { background: var(--vscode-textCodeBlock-background); padding: 6px; overflow-x: auto; }
-      .muted { opacity: 0.7; }
-      button { margin-right: 6px; }
+      body { font-family: var(--vscode-font-family); font-size: 13px; padding: 12px 16px; line-height: 1.5; }
+      h2 { margin: 0 0 4px; font-size: 1.15em; }
+      h3 { margin: 16px 0 6px; font-size: 1em; }
+      p { margin: 8px 0; }
+      pre {
+        background: var(--vscode-textCodeBlock-background);
+        padding: 10px 12px;
+        margin: 4px 0 12px;
+        border-radius: 4px;
+        line-height: 1.45;
+        overflow-x: auto;
+      }
+      .muted { opacity: 0.7; margin-bottom: 12px; display: block; }
+      .actions { margin-top: 16px; display: flex; gap: 8px; }
+      button { padding: 4px 12px; }
+      ul { margin: 6px 0; padding-left: 20px; }
+      li { margin: 3px 0; }
     </style></head>
     <body>${body}
     <script>const vscode = acquireVsCodeApi(); function post(type) { vscode.postMessage({ type }); }</script>

--- a/vscode-plustan/src/ui/detailPanel.ts
+++ b/vscode-plustan/src/ui/detailPanel.ts
@@ -31,9 +31,11 @@ export class FindingDetailProvider implements vscode.WebviewViewProvider {
   }
 
   showFinding(finding: SessionFinding, inspection: InspectionV2 | undefined): void {
+    // Update the content but do NOT force the (collapsed-by-default) view open —
+    // it only takes screen space when the user expands it themselves, at which
+    // point resolveWebviewView renders whatever finding is currently selected.
     this.current = { finding, inspection };
     this.render();
-    this.view?.show?.(true);
   }
 
   clear(): void {

--- a/vscode-plustan/src/ui/detailPanel.ts
+++ b/vscode-plustan/src/ui/detailPanel.ts
@@ -1,0 +1,100 @@
+import * as vscode from "vscode";
+import { InspectionV2 } from "../core/schema";
+import { SessionFinding } from "../core/sessionState";
+
+const RULES_URL = "https://github.com/input-output-hk/plu-stan/blob/main/RULES.md";
+
+export class FindingDetailProvider implements vscode.WebviewViewProvider {
+  static readonly viewId = "plustanFindingDetail";
+  private view: vscode.WebviewView | undefined;
+  private current: { finding: SessionFinding; inspection?: InspectionV2 } | undefined;
+
+  constructor(
+    private readonly onDismiss: (finding: SessionFinding) => void,
+    private readonly onOpen: (finding: SessionFinding) => void
+  ) {}
+
+  resolveWebviewView(view: vscode.WebviewView): void {
+    this.view = view;
+    view.webview.options = { enableScripts: true };
+    view.webview.onDidReceiveMessage((msg: { type: string }) => {
+      if (!this.current) {
+        return;
+      }
+      if (msg.type === "dismiss") {
+        this.onDismiss(this.current.finding);
+      } else if (msg.type === "open") {
+        this.onOpen(this.current.finding);
+      }
+    });
+    this.render();
+  }
+
+  showFinding(finding: SessionFinding, inspection: InspectionV2 | undefined): void {
+    this.current = { finding, inspection };
+    this.render();
+    this.view?.show?.(true);
+  }
+
+  clear(): void {
+    this.current = undefined;
+    this.render();
+  }
+
+  private render(): void {
+    if (!this.view) {
+      return;
+    }
+    this.view.webview.html = this.current
+      ? findingHtml(this.current.finding, this.current.inspection)
+      : emptyHtml();
+  }
+}
+
+function esc(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function emptyHtml(): string {
+  return wrap("<p class='muted'>Select a finding in the tree to see its explanation.</p>");
+}
+
+function findingHtml(f: SessionFinding, inspection: InspectionV2 | undefined): string {
+  const name = inspection?.name ?? f.inspectionId;
+  const severity = inspection?.severity ?? "";
+  const why = inspection?.whyItMatters ?? inspection?.description ?? "";
+  const solutions = (inspection?.solution ?? []).map((s) => `<li>${esc(s)}</li>`).join("");
+  const docsLink = inspection?.docsAnchor
+    ? `<a href="${RULES_URL}#${esc(inspection.docsAnchor)}">Rule documentation</a>`
+    : "";
+  const examples = inspection?.badExample && inspection?.goodExample
+    ? `<h3>✗ Avoid</h3><pre>${esc(inspection.badExample)}</pre>
+       <h3>✓ Prefer</h3><pre>${esc(inspection.goodExample)}</pre>`
+    : "";
+  return wrap(`
+    <h2>${esc(f.inspectionId)} · ${esc(name)}</h2>
+    <p class="muted">${esc(severity)} · ${esc(f.file)}:${f.startLine}:${f.startCol} · status: ${esc(f.status)}</p>
+    ${why ? `<p>${esc(why)}</p>` : ""}
+    ${examples}
+    ${solutions ? `<h3>How to fix</h3><ul>${solutions}</ul>` : ""}
+    <p>${docsLink}</p>
+    <div class="actions">
+      <button onclick="post('open')">Open file</button>
+      <button onclick="post('dismiss')">Dismiss</button>
+    </div>
+  `);
+}
+
+function wrap(body: string): string {
+  return `<!DOCTYPE html><html><head><meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
+    <style>
+      body { font-family: var(--vscode-font-family); font-size: 13px; padding: 8px; }
+      pre { background: var(--vscode-textCodeBlock-background); padding: 6px; overflow-x: auto; }
+      .muted { opacity: 0.7; }
+      button { margin-right: 6px; }
+    </style></head>
+    <body>${body}
+    <script>const vscode = acquireVsCodeApi(); function post(type) { vscode.postMessage({ type }); }</script>
+    </body></html>`;
+}

--- a/vscode-plustan/src/ui/detailPanel.ts
+++ b/vscode-plustan/src/ui/detailPanel.ts
@@ -71,9 +71,13 @@ function findingHtml(f: SessionFinding, inspection: InspectionV2 | undefined): s
     ? `<h3>✗ Avoid</h3><pre>${esc(inspection.badExample)}</pre>
        <h3>✓ Prefer</h3><pre>${esc(inspection.goodExample)}</pre>`
     : "";
+  const dismissalNote = f.status === "dismissed" && f.dismissalNote
+    ? `<p class="muted">Dismissed — ${esc(f.dismissalNote)}</p>`
+    : "";
   return wrap(`
     <h2>${esc(f.inspectionId)} · ${esc(name)}</h2>
     <p class="muted">${esc(severity)} · ${esc(f.file)}:${f.startLine}:${f.startCol} · status: ${esc(f.status)}</p>
+    ${dismissalNote}
     ${why ? `<p>${esc(why)}</p>` : ""}
     ${examples}
     ${solutions ? `<h3>How to fix</h3><ul>${solutions}</ul>` : ""}

--- a/vscode-plustan/src/ui/findingsTree.ts
+++ b/vscode-plustan/src/ui/findingsTree.ts
@@ -8,10 +8,15 @@ type Grouping = "severity" | "module";
 const SEVERITY_ORDER = ["Error", "Warning", "PotentialBug", "Performance", "Style"];
 
 class GroupItem extends vscode.TreeItem {
-  constructor(label: string, readonly children: (GroupItem | FindingTreeItem)[], icon?: string) {
+  constructor(
+    label: string,
+    readonly children: (GroupItem | FindingTreeItem)[],
+    icon?: string,
+    iconColor?: vscode.ThemeColor
+  ) {
     super(label, vscode.TreeItemCollapsibleState.Expanded);
     if (icon) {
-      this.iconPath = new vscode.ThemeIcon(icon);
+      this.iconPath = new vscode.ThemeIcon(icon, iconColor);
     }
   }
 }
@@ -25,12 +30,19 @@ export class FindingTreeItem extends vscode.TreeItem {
       this.tooltip += `\nDismissed: ${finding.dismissalNote}`;
     }
     this.contextValue = finding.status === "dismissed" ? "plustanDismissedFinding" : "plustanFinding";
-    this.iconPath = new vscode.ThemeIcon(
+    // Icon *shape* encodes status; icon *color* encodes severity. Active
+    // findings (open/stale) get the severity colour so the tree reads as a
+    // colour-coded list; resolved findings are neutral (green check / muted slash).
+    const shape =
       finding.status === "stale" ? "history"
         : finding.status === "fixed" ? "check"
         : finding.status === "dismissed" ? "circle-slash"
-        : "warning"
-    );
+        : "circle-filled";
+    const color =
+      finding.status === "fixed" ? new vscode.ThemeColor("charts.green")
+        : finding.status === "dismissed" ? new vscode.ThemeColor("descriptionForeground")
+        : severityColor(inspection?.severity);
+    this.iconPath = new vscode.ThemeIcon(shape, color);
     if (finding.status === "stale") {
       this.description = `~ ${this.description ?? ""}`;
     }
@@ -106,9 +118,14 @@ export class FindingsTreeProvider implements vscode.TreeDataProvider<Node> {
       const ruleNodes = ruleIds.map((ruleId) => {
         const inRule = inSeverity.filter((f) => f.inspectionId === ruleId).sort(bySpan);
         const name = this.inspections.get(ruleId)?.name ?? "";
-        return new GroupItem(`${ruleId} ${name} (${inRule.length})`, inRule.map((f) => this.item(f)));
+        return new GroupItem(
+          `${ruleId} ${name} (${inRule.length})`,
+          inRule.map((f) => this.item(f)),
+          "circle-filled",
+          severityColor(severity)
+        );
       });
-      return new GroupItem(`${severity} (${inSeverity.length})`, ruleNodes, severityIcon(severity));
+      return new GroupItem(`${severity} (${inSeverity.length})`, ruleNodes, severityIcon(severity), severityColor(severity));
     });
   }
 
@@ -131,4 +148,20 @@ function bySpan(a: SessionFinding, b: SessionFinding): number {
 
 function severityIcon(severity: string): string {
   return severity === "Error" ? "error" : severity === "Performance" ? "zap" : "warning";
+}
+
+/**
+ * Severity → theme colour for icon tinting. Uses the built-in `charts.*`
+ * palette so it adapts to light/dark themes. `undefined` (unknown severity)
+ * falls back to the icon's default colour.
+ */
+function severityColor(severity: string | undefined): vscode.ThemeColor | undefined {
+  switch (severity) {
+    case "Error": return new vscode.ThemeColor("charts.red");
+    case "Warning": return new vscode.ThemeColor("charts.yellow");
+    case "PotentialBug": return new vscode.ThemeColor("charts.orange");
+    case "Performance": return new vscode.ThemeColor("charts.blue");
+    case "Style": return new vscode.ThemeColor("charts.purple");
+    default: return undefined;
+  }
 }

--- a/vscode-plustan/src/ui/findingsTree.ts
+++ b/vscode-plustan/src/ui/findingsTree.ts
@@ -21,6 +21,9 @@ export class FindingTreeItem extends vscode.TreeItem {
     super(`${path.basename(finding.file)}:${finding.startLine}`, vscode.TreeItemCollapsibleState.None);
     this.description = inspection ? inspection.name : finding.inspectionId;
     this.tooltip = `[${finding.inspectionId}] ${finding.file}:${finding.startLine}:${finding.startCol}`;
+    if (finding.status === "dismissed" && finding.dismissalNote) {
+      this.tooltip += `\nDismissed: ${finding.dismissalNote}`;
+    }
     this.contextValue = finding.status === "dismissed" ? "plustanDismissedFinding" : "plustanFinding";
     this.iconPath = new vscode.ThemeIcon(
       finding.status === "stale" ? "history"

--- a/vscode-plustan/src/ui/findingsTree.ts
+++ b/vscode-plustan/src/ui/findingsTree.ts
@@ -1,0 +1,131 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { InspectionV2 } from "../core/schema";
+import { SessionFinding, SessionState, initialSessionState } from "../core/sessionState";
+
+type Grouping = "severity" | "module";
+
+const SEVERITY_ORDER = ["Error", "Warning", "PotentialBug", "Performance", "Style"];
+
+class GroupItem extends vscode.TreeItem {
+  constructor(label: string, readonly children: (GroupItem | FindingTreeItem)[], icon?: string) {
+    super(label, vscode.TreeItemCollapsibleState.Expanded);
+    if (icon) {
+      this.iconPath = new vscode.ThemeIcon(icon);
+    }
+  }
+}
+
+export class FindingTreeItem extends vscode.TreeItem {
+  constructor(readonly finding: SessionFinding, inspection: InspectionV2 | undefined) {
+    super(`${path.basename(finding.file)}:${finding.startLine}`, vscode.TreeItemCollapsibleState.None);
+    this.description = inspection ? inspection.name : finding.inspectionId;
+    this.tooltip = `[${finding.inspectionId}] ${finding.file}:${finding.startLine}:${finding.startCol}`;
+    this.contextValue = finding.status === "dismissed" ? "plustanDismissedFinding" : "plustanFinding";
+    this.iconPath = new vscode.ThemeIcon(
+      finding.status === "stale" ? "history"
+        : finding.status === "fixed" ? "check"
+        : finding.status === "dismissed" ? "circle-slash"
+        : "warning"
+    );
+    if (finding.status === "stale") {
+      this.description = `~ ${this.description ?? ""}`;
+    }
+    this.command = { command: "plustan.openFinding", title: "Open Finding", arguments: [this] };
+  }
+}
+
+type Node = GroupItem | FindingTreeItem;
+
+export class FindingsTreeProvider implements vscode.TreeDataProvider<Node> {
+  private state: SessionState = initialSessionState;
+  private inspections = new Map<string, InspectionV2>();
+  private grouping: Grouping = "severity";
+  private readonly emitter = new vscode.EventEmitter<Node | undefined>();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  setData(state: SessionState, inspections: Map<string, InspectionV2>): void {
+    this.state = state;
+    this.inspections = inspections;
+    this.emitter.fire(undefined);
+  }
+
+  toggleGrouping(): void {
+    this.grouping = this.grouping === "severity" ? "module" : "severity";
+    this.emitter.fire(undefined);
+  }
+
+  getTreeItem(element: Node): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: Node): Node[] {
+    if (element) {
+      return element instanceof GroupItem ? element.children : [];
+    }
+    if (this.state.phase === "idle") {
+      const idle = new vscode.TreeItem("No active review — press ▶ to start");
+      return [idle as Node];
+    }
+    return this.buildRoots();
+  }
+
+  private buildRoots(): Node[] {
+    const all = Object.values(this.state.findings);
+    const active = all.filter((f) => f.status === "open" || f.status === "stale");
+    const fixed = all.filter((f) => f.status === "fixed");
+    const dismissed = all.filter((f) => f.status === "dismissed");
+
+    const roots: Node[] = this.grouping === "severity"
+      ? this.groupBySeverity(active)
+      : this.groupByModule(active);
+
+    if (fixed.length > 0) {
+      const node = new GroupItem(`Fixed this session (${fixed.length})`, fixed.map((f) => this.item(f)), "check");
+      node.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+      roots.push(node);
+    }
+    if (dismissed.length > 0) {
+      const node = new GroupItem(`Dismissed (${dismissed.length})`, dismissed.map((f) => this.item(f)), "circle-slash");
+      node.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+      roots.push(node);
+    }
+    return roots;
+  }
+
+  private groupBySeverity(findings: SessionFinding[]): Node[] {
+    const severityOf = (f: SessionFinding): string => this.inspections.get(f.inspectionId)?.severity ?? "Warning";
+    const severities = [...new Set(findings.map(severityOf))]
+      .sort((a, b) => SEVERITY_ORDER.indexOf(a) - SEVERITY_ORDER.indexOf(b));
+    return severities.map((severity) => {
+      const inSeverity = findings.filter((f) => severityOf(f) === severity);
+      const ruleIds = [...new Set(inSeverity.map((f) => f.inspectionId))].sort();
+      const ruleNodes = ruleIds.map((ruleId) => {
+        const inRule = inSeverity.filter((f) => f.inspectionId === ruleId).sort(bySpan);
+        const name = this.inspections.get(ruleId)?.name ?? "";
+        return new GroupItem(`${ruleId} ${name} (${inRule.length})`, inRule.map((f) => this.item(f)));
+      });
+      return new GroupItem(`${severity} (${inSeverity.length})`, ruleNodes, severityIcon(severity));
+    });
+  }
+
+  private groupByModule(findings: SessionFinding[]): Node[] {
+    const modules = [...new Set(findings.map((f) => f.moduleName))].sort();
+    return modules.map((moduleName) => {
+      const inModule = findings.filter((f) => f.moduleName === moduleName).sort(bySpan);
+      return new GroupItem(`${moduleName} (${inModule.length})`, inModule.map((f) => this.item(f)), "symbol-module");
+    });
+  }
+
+  private item(f: SessionFinding): FindingTreeItem {
+    return new FindingTreeItem(f, this.inspections.get(f.inspectionId));
+  }
+}
+
+function bySpan(a: SessionFinding, b: SessionFinding): number {
+  return a.file.localeCompare(b.file) || a.startLine - b.startLine || a.startCol - b.startCol;
+}
+
+function severityIcon(severity: string): string {
+  return severity === "Error" ? "error" : severity === "Performance" ? "zap" : "warning";
+}

--- a/vscode-plustan/src/ui/statusBar.ts
+++ b/vscode-plustan/src/ui/statusBar.ts
@@ -14,10 +14,15 @@ export class PluStanStatusBar implements vscode.Disposable {
       this.item.hide();
       return;
     }
+    if (running) {
+      this.item.text = "$(sync~spin) Plu-Stan: analyzing…";
+      this.item.tooltip = "Plu-Stan is running an analysis…";
+      this.item.show();
+      return;
+    }
     const counts = countByStatus(state);
-    const spinner = running ? "$(sync~spin) " : "";
-    const failure = buildFailed ? " · build failed — results stale" : "";
-    this.item.text = `${spinner}Plu-Stan: ${counts.open + counts.stale} open · ${counts.fixed} fixed${failure}`;
+    const failure = buildFailed ? " · $(warning) build failed — results stale" : "";
+    this.item.text = `Plu-Stan: ${counts.open + counts.stale} open · ${counts.fixed} fixed${failure}`;
     this.item.tooltip = "Plu-Stan review session — click to open findings";
     this.item.show();
   }

--- a/vscode-plustan/src/ui/statusBar.ts
+++ b/vscode-plustan/src/ui/statusBar.ts
@@ -1,0 +1,28 @@
+import * as vscode from "vscode";
+import { countByStatus, SessionState } from "../core/sessionState";
+
+export class PluStanStatusBar implements vscode.Disposable {
+  private readonly item: vscode.StatusBarItem;
+
+  constructor() {
+    this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 50);
+    this.item.command = "plustanFindings.focus";
+  }
+
+  update(state: SessionState, running: boolean, buildFailed: boolean): void {
+    if (state.phase === "idle") {
+      this.item.hide();
+      return;
+    }
+    const counts = countByStatus(state);
+    const spinner = running ? "$(sync~spin) " : "";
+    const failure = buildFailed ? " · build failed — results stale" : "";
+    this.item.text = `${spinner}Plu-Stan: ${counts.open + counts.stale} open · ${counts.fixed} fixed${failure}`;
+    this.item.tooltip = "Plu-Stan review session — click to open findings";
+    this.item.show();
+  }
+
+  dispose(): void {
+    this.item.dispose();
+  }
+}

--- a/vscode-plustan/test-fixtures/fake-plustan
+++ b/vscode-plustan/test-fixtures/fake-plustan
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec node "$(dirname "$0")/fake-plustan.js" "$@"

--- a/vscode-plustan/test-fixtures/fake-plustan.js
+++ b/vscode-plustan/test-fixtures/fake-plustan.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Stub plustan for tests: emits canned schema-v2 JSON per subcommand.
+const cmd = process.argv[2];
+const payloads = {
+  capabilities: { schemaVersion: 2, ghcVersion: "9.6", features: ["list-onchain", "analyze", "fingerprints", "inspection-docs"] },
+  "list-onchain": {
+    version: 2, workspaceRoot: process.cwd(), hieDir: ".hie",
+    modules: [{ moduleName: "Fixture.Validator", file: "src/Fixture/Validator.hs", annotationSource: "source" }]
+  },
+  analyze: {
+    version: 2, runScope: process.argv.includes("--module") ? "module" : "all",
+    targetModule: null,
+    inspections: [{
+      id: "PLU-STAN-04", name: "Credential equality", description: "desc", solution: ["sol"],
+      category: ["Plutus"], severity: "Warning",
+      whyItMatters: "staking theft", badExample: "bad", goodExample: "good", docsAnchor: "equality"
+    }],
+    observations: [
+      { id: "o1", inspectionId: "PLU-STAN-04", fingerprint: "FPR-PLU-STAN-04-aaa-bbb",
+        file: "src/Fixture/Validator.hs", moduleName: "Fixture.Validator",
+        startLine: 3, startCol: 1, endLine: 3, endCol: 10 },
+      { id: "o2", inspectionId: "PLU-STAN-04", fingerprint: "FPR-PLU-STAN-04-aaa-ccc",
+        file: "src/Fixture/Validator.hs", moduleName: "Fixture.Validator",
+        startLine: 7, startCol: 1, endLine: 7, endCol: 10 }
+    ]
+  }
+};
+const p = payloads[cmd];
+if (!p) { process.stderr.write(`unknown command ${cmd}\n`); process.exit(1); }
+process.stdout.write(JSON.stringify(p) + "\n");

--- a/vscode-plustan/test-fixtures/workspace/.vscode/settings.json
+++ b/vscode-plustan/test-fixtures/workspace/.vscode/settings.json
@@ -1,0 +1,1 @@
+{ "plustan.binaryPath": "${workspaceFolder}/../fake-plustan" }

--- a/vscode-plustan/test-fixtures/workspace/src/Fixture/Validator.hs
+++ b/vscode-plustan/test-fixtures/workspace/src/Fixture/Validator.hs
@@ -1,0 +1,5 @@
+module Fixture.Validator where
+{-# ANN module ("onchain-contract" :: String) #-}
+
+validator :: Bool
+validator = True


### PR DESCRIPTION
## Summary

Phase 1 of a **review-cockpit** for the `vscode-plustan` extension, plus the backend changes it needs. Turns the MVP CLI-wrapper into an on-demand contract-review experience for Plinth developers.

**Extension (`vscode-plustan/`, v0.3.0)**
- Review-session workflow: **Start Review** → findings tree grouped by severity → rule → **detail panel** with per-rule teaching docs (why-it-matters, ✗ bad / ✓ good examples, fix guidance, RULES.md link) → **Dismiss** (persists to `.plustan/dismissals.json`) / Restore → editing a reviewed file marks findings **stale** and auto re-runs analysis for that module on save → **End Review**.
- Status bar (`N open · M fixed`), squiggles + Problems entries, dismiss-from-editor code action.
- Restructured into a vscode-free, unit-tested `core/` (schema validation, session reducer, dismissals, run coalescer) + `analyzer/client.ts` seam (typed failure classification, `AbortSignal` cancellation) + thin vscode-coupled shell. A future daemon backend is a transport swap.
- Legacy one-shot Run Workspace/Run Module retained, disabled during an active session.

**Backend (`plustan`, stan.cabal 0.2.5.0)**
- Position-independent observation **fingerprints** (hash of rule + module + flagged span text) — survive edits elsewhere in a file; drive dismissals and open/fixed tracking.
- Per-rule **teaching docs** for all 19 PLU-STAN rules (`Stan.Plinth.Docs`).
- **Schema-v2** JSON payload (`Stan.Plinth.Payload`) with unique fingerprints; new `capabilities` handshake subcommand so extension/binary version drift fails with a clear "check for updates" prompt instead of a silent misparse.

Deferred to later phases (per the design spec): backend-computed quick fixes, AI handoff, CLI reading `.plustan/dismissals.json` for CI parity, daemon/LSP.

Design + plan: `docs/superpowers/specs/2026-07-06-vscode-review-cockpit-design.md`, `docs/superpowers/plans/2026-07-06-vscode-review-cockpit-phase1.md`.

## Test Plan

- [x] Backend `cabal test` green (301 examples incl. fingerprint stability, docs coverage for all 19 rules, golden schema-v2 wire contract).
- [x] Extension unit tests: `npm run test:unit` → 47 passing (vscode-free core + analyzer client).
- [x] Extension integration: `npm run test:integration` → 1 passing under real VS Code 1.127.0 (start review → diagnostics via stub binary).
- [x] Real end-to-end: extension + locally-built binary against `target/Target/PlutusTx.hs` → 314 findings across all 19 rules, matching the CLI.
- [ ] Reviewer: interactive smoke — set `plustan.binaryPath`, open the repo, Start Review, click a finding, dismiss, edit+save to see auto re-run.

## Known limitation (Phase 2 follow-up)

Duplicate byte-identical findings of the same rule in one module share a base fingerprint disambiguated by a run-local `#n` suffix; dismissing one then editing it can migrate the dismissal to its twin. Narrow, recoverable; hardening tracked in the design spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)