### PR TITLE
fix(release): ship one binary per GHC minor series, not per patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,16 +34,21 @@ jobs:
       # the release regardless (see promote_release).
       fail-fast: false
       matrix:
-        # stan reads .hie files, whose on-disk format is locked to the exact
-        # GHC PATCH version that produced them (the binary panics with
-        # "readHieFile: hie file versions" otherwise). So we ship one binary
-        # *per GHC patch*, and the extension downloads the one matching the
-        # user's project GHC. The set below is what CI proves green on all
-        # three OSes; expand it to cover the GHC patches your users run.
+        # stan reads .hie files. GHC bumps the .hie format version on every
+        # patch release, but the on-disk format is stable *within* a minor
+        # series, and the binary now reads any patch in its series (see
+        # Stan.Hie.Compat904 / PR #52). So we ship one binary *per minor
+        # series* and the extension picks the one matching the user's project
+        # GHC series. Future patch releases (e.g. 9.6.8, 9.12.3) need no new
+        # build — an existing series binary already reads them.
         #
-        # `os` and `ghc` are BOTH base dimensions -> the full 3x4 = 12 jobs.
+        # PlutusTx (plutus-tx-plugin) only builds on GHC 9.6 and 9.12, and a
+        # Cabal project is single-GHC, so every .hie a PlutusTx project emits
+        # is 9.6.x or 9.12.x. Hence exactly these two series, latest patch each.
+        #
+        # `os` and `ghc` are BOTH base dimensions -> the full 3x2 = 6 jobs.
         # The `include` block only attaches target/ext to each `os` value.
-        ghc: ["9.6.7", "9.8.4", "9.10.3", "9.12.2"]
+        ghc: ["9.6.7", "9.12.2"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - { os: ubuntu-latest,  target: linux-x64,    ext: "" }
@@ -113,7 +118,10 @@ jobs:
 
       - name: Upload plustan asset
         run: |
-          ASSET="plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}-ghc${{ matrix.ghc }}${{ matrix.ext }}"
+          # Name the asset by GHC minor series (9.6.7 -> 9.6): one binary reads
+          # every patch in its series, and the extension matches on the series.
+          GHC_SERIES=$(echo "${{ matrix.ghc }}" | cut -d. -f1,2)
+          ASSET="plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}-ghc${GHC_SERIES}${{ matrix.ext }}"
           cp "./dist/plustan${{ matrix.ext }}" "./dist/${ASSET}"
           gh release upload ${{ github.ref_name }} "./dist/${ASSET}"
         env:

--- a/vscode-plustan/src/downloadManager.ts
+++ b/vscode-plustan/src/downloadManager.ts
@@ -4,9 +4,10 @@ import * as path from "node:path";
 import * as vscode from "vscode";
 
 const GITHUB_API_LATEST = "https://api.github.com/repos/input-output-hk/plu-stan/releases/latest";
-// Map of GHC version -> { path, version } for binaries we've downloaded.
-// stan reads .hie files whose format is locked to the exact GHC version, so we
-// cache (and download) one binary per GHC rather than a single global one.
+// Map of GHC major.minor series -> { path, version } for binaries we've
+// downloaded. A plustan build reads every .hie file produced by its GHC series
+// (patch releases share the on-disk format), so we cache and download one
+// binary per series rather than per patch or a single global one.
 const CACHED_BINARIES_KEY = "plustan.cachedBinaries";
 
 type Platform = "linux-x64" | "darwin-arm64" | "windows-x64";
@@ -29,19 +30,31 @@ function platformExt(platform: Platform): string {
   return platform === "windows-x64" ? ".exe" : "";
 }
 
+/**
+ * The GHC major.minor series of a version string, e.g. "9.6.3" -> "9.6".
+ *
+ * A single plustan build reads every .hie file produced by its GHC series: GHC
+ * bumps the .hie format version on every patch release, but the on-disk format
+ * only changes across minor series. So binaries are shipped, matched and cached
+ * per series, not per patch.
+ */
+function ghcSeries(ghc: string): string {
+  return ghc.split(".").slice(0, 2).join(".");
+}
+
 function assetName(version: string, platform: Platform, ghc: string): string {
-  return `plustan-${version}-${platform}-ghc${ghc}${platformExt(platform)}`;
+  return `plustan-${version}-${platform}-ghc${ghcSeries(ghc)}${platformExt(platform)}`;
 }
 
 /**
  * Detect the GHC version a project's .hie files were built with.
  *
- * stan consumes .hie files, and their on-disk format is locked to the exact
- * GHC version that produced them — a binary built with a different GHC panics
- * with `readHieFile: hie file versions`. Every .hie file begins with a
- * plaintext header like `HIE9063\n9.6.3\n`, so we read the version straight
- * from the same artifact the binary will read. That is exactly the GHC the
- * downloaded binary must match.
+ * stan consumes .hie files, whose on-disk format is tied to the GHC major.minor
+ * series that produced them: patch releases within a series share a format, but
+ * a binary from a different series can't read them. Every .hie file begins with
+ * a plaintext header like `HIE9063\n9.6.3\n`, so we read the full version
+ * straight from the same artifact the binary will read; the binary is then
+ * matched by its series (see `ghcSeries`).
  */
 export function detectProjectGhc(hieDir: string, projectDir: string): string | null {
   const absHieDir = path.isAbsolute(hieDir) ? hieDir : path.join(projectDir, hieDir);
@@ -91,7 +104,7 @@ interface GitHubRelease {
   assets: Array<{ name: string; browser_download_url: string }>;
 }
 
-/** GHC versions a release ships a binary for on the given platform. */
+/** GHC minor series a release ships a binary for on the given platform. */
 function availableGhcsFor(release: GitHubRelease, platform: Platform): string[] {
   const ext = platformExt(platform).replace(".", "\\.");
   const re = new RegExp(`^plustan-.+-${platform}-ghc([0-9]+(?:\\.[0-9]+)+)${ext}$`);
@@ -165,7 +178,7 @@ export function getCachedBinaryPath(globalState: vscode.Memento, ghc: string | n
   if (!ghc) {
     return undefined;
   }
-  const entry = getCacheMap(globalState)[ghc];
+  const entry = getCacheMap(globalState)[ghcSeries(ghc)];
   if (entry && fs.existsSync(entry.path)) {
     return entry.path;
   }
@@ -233,11 +246,11 @@ export async function downloadLatest(
         if (!asset) {
           const available = availableGhcsFor(release, resolved);
           throw new Error(
-            `No prebuilt plustan for GHC ${ghc} on ${resolved} in release ${release.tag_name}. ` +
+            `No prebuilt plustan for GHC ${ghc} (series ${ghcSeries(ghc)}) on ${resolved} in release ${release.tag_name}. ` +
             (available.length
-              ? `That release ships binaries for GHC: ${available.join(", ")}. `
+              ? `That release ships binaries for GHC series: ${available.join(", ")}. `
               : `That release ships no ${resolved} binaries. `) +
-            `Rebuild your project with one of those GHC versions, or build plustan with GHC ${ghc} ` +
+            `Rebuild your project with a GHC from one of those series, or build plustan with GHC ${ghc} ` +
             `and point \`plustan.binaryPath\` at it.`
           );
         }
@@ -248,7 +261,7 @@ export async function downloadLatest(
         }
 
         const ext = platformExt(resolved);
-        const binaryPath = path.join(storageDir, `plustan-ghc${ghc}${ext}`);
+        const binaryPath = path.join(storageDir, `plustan-ghc${ghcSeries(ghc)}${ext}`);
 
         output.appendLine(`Plu-Stan: downloading ${name}...`);
         await downloadFile(asset.browser_download_url, binaryPath, token);
@@ -258,7 +271,7 @@ export async function downloadLatest(
         }
 
         const cache = getCacheMap(context.globalState);
-        cache[ghc] = { path: binaryPath, version };
+        cache[ghcSeries(ghc)] = { path: binaryPath, version };
         await context.globalState.update(CACHED_BINARIES_KEY, cache);
 
         output.appendLine(`Plu-Stan: ${version} (GHC ${ghc}) installed at ${binaryPath}`);
@@ -297,7 +310,7 @@ export async function checkForUpdates(
     output.appendLine(`Plu-Stan: checking for updates (GHC ${ghc})...`);
     const release = await fetchJson(GITHUB_API_LATEST) as GitHubRelease;
     const latestVersion = release.tag_name.replace(/^v/, "");
-    const cachedVersion = getCacheMap(context.globalState)[ghc]?.version;
+    const cachedVersion = getCacheMap(context.globalState)[ghcSeries(ghc)]?.version;
 
     if (cachedVersion === latestVersion) {
       vscode.window.showInformationMessage(`Plu-Stan: already up to date (${latestVersion}, GHC ${ghc}).`);

--- a/vscode-plustan/src/extension.ts
+++ b/vscode-plustan/src/extension.ts
@@ -637,15 +637,15 @@ async function runPluStanJson<T>(
 /** Turn a no-JSON plustan run into an actionable, user-facing message. */
 function describePluStanFailure(stdout: string, stderr: string, exitCode: number): string {
   const haystack = `${stderr}\n${stdout}`;
-  const ghcMismatch = /hie file versions|readHieFile|built by a different ghc|different ghc/i.test(haystack);
+  const ghcMismatch = /hie file versions|readHieFile|cannot read the \.hie file|major\.minor series|built by a different ghc|different ghc/i.test(haystack);
   const panicked = /panic!|the 'impossible' happened/i.test(haystack);
 
   if (ghcMismatch) {
     return (
-      "Plu-Stan couldn't read your project's .hie files: they were built with a different GHC " +
-      "than the plustan binary. Rebuild your project with the GHC the binary targets, or run " +
-      "\"Plu-Stan: Check for Updates\" to fetch a binary matching your project's GHC. " +
-      "(Full output is in the Plu-Stan output channel.)"
+      "Plu-Stan couldn't read your project's .hie files: they were built with a GHC from a " +
+      "different major.minor series than the plustan binary. Rebuild your project with a GHC in " +
+      "the series the binary targets, or run \"Plu-Stan: Check for Updates\" to fetch a binary " +
+      "matching your project's GHC series. (Full output is in the Plu-Stan output channel.)"
     );
   }
 


### PR DESCRIPTION
Stacks on **#52** (Compat904 reads any `.hie` in its GHC minor series) and on this branch's per-GHC distribution work. Base is `fix/plustan-multi-ghc-distribution` so the diff shows only this delta.

## Release matrix (`.github/workflows/release.yml`)

- **Drop GHC 9.8.4 and 9.10.3.** `plutus-tx-plugin` only builds on GHC **9.6** and **9.12**, and a Cabal project is single-GHC — so a PlutusTx project never emits 9.8/9.10 `.hie` files. Those binaries were dead weight.
- **One latest patch per supported series** (`9.6.7`, `9.12.2` — both already CI-green on this branch). Matrix **12 → 6 jobs**.
- Future patch releases (9.6.8, 9.12.3, …) need **no new build** — an existing series binary already reads them (that's #52).
- **Assets named by series**: `plustan-<ver>-<target>-ghc9.6`.

## Extension (`downloadManager.ts`, `extension.ts`)

- New `ghcSeries()` helper; binaries are **matched, cached and named by GHC major.minor series**. A project on 9.6.5 now gets the `ghc9.6` binary instead of failing an exact-version lookup against a `ghc9.6.7` asset.
- `detectProjectGhc` still returns the full version (for user-facing messages); only matching reduces to the series.
- Mismatch detector broadened to also catch #52's new error text; its hint reworded in series terms.

## Verification

- `npm run compile` (`tsc -p ./`) — clean, exit 0.
- `release.yml` parses as valid YAML.
- End-to-end name agreement: `ghcSeries("9.6.5") === "9.6"` and `echo 9.6.7 | cut -d. -f1,2 === "9.6"` — the extension's computed asset name matches the one CI uploads.

## Merge order

Depends on **#52** for correctness (shipping one-per-series is only safe once the reader tolerates patch differences). Merge #52 first, or together.

## Not included (deliberate)

The redundant per-patch `stack-ghc-9.6.*.yaml` dev files + their `stan.cabal` `extra-source-files` entries are a separate cleanup — left out to keep this PR focused on release + extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)