### PR TITLE
fix: distribute plustan per-GHC and fail loudly on GHC mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,20 +21,34 @@ jobs:
 
   build_plustan_canonical:
     needs: [create_release]
-    name: plustan / ${{ matrix.target }}
+    name: plustan / ${{ matrix.target }} / ghc ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        # Use bash on every OS (including the Windows runner's Git bash) so the
+        # build/upload steps below share a single, portable shell.
+        shell: bash
     strategy:
+      # Don't fail fast: one GHC/platform leg failing must not stop the others
+      # from shipping. Whatever builds gets uploaded; the publish job promotes
+      # the release regardless (see promote_release).
       fail-fast: false
       matrix:
+        # stan reads .hie files, whose on-disk format is locked to the exact
+        # GHC PATCH version that produced them (the binary panics with
+        # "readHieFile: hie file versions" otherwise). So we ship one binary
+        # *per GHC patch*, and the extension downloads the one matching the
+        # user's project GHC. The set below is what CI proves green on all
+        # three OSes; expand it to cover the GHC patches your users run.
+        #
+        # `os` and `ghc` are BOTH base dimensions -> the full 3x4 = 12 jobs.
+        # The `include` block only attaches target/ext to each `os` value.
+        ghc: ["9.6.7", "9.8.4", "9.10.3", "9.12.2"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
-          - os: ubuntu-latest
-            target: linux-x64
-            binary: plustan
-            ext: ""
-          - os: macos-latest
-            target: darwin-arm64
-            binary: plustan
-            ext: ""
+          - { os: ubuntu-latest,  target: linux-x64,    ext: "" }
+          - { os: macos-latest,   target: darwin-arm64, ext: "" }
+          - { os: windows-latest, target: windows-x64,  ext: ".exe" }
 
     steps:
       - name: Check out code
@@ -51,7 +65,7 @@ jobs:
         uses: haskell-actions/setup@v2
         id: setup-haskell-cabal
         with:
-          ghc-version: "9.6.6"
+          ghc-version: ${{ matrix.ghc }}
           cabal-version: "3.12"
 
       - name: Install system dependencies (Linux)
@@ -79,6 +93,10 @@ jobs:
           printf "Name: libblst\nVersion: 0.3\nDescription: BLS12-381 signature library\nLibs: -L$BREW_PREFIX/lib -lblst\nCflags: -I$BREW_PREFIX/include\n" > "$BREW_PREFIX/lib/pkgconfig/libblst.pc"
           echo "PKG_CONFIG_PATH=$BREW_PREFIX/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}" >> "$GITHUB_ENV"
 
+      # Windows needs no manual Cardano system libraries: CI builds the full
+      # stack green on windows-latest without them (haskell-actions/setup pulls
+      # what's required). So there is no Windows dependency step on purpose.
+
       - name: Freeze
         run: cabal freeze
 
@@ -86,16 +104,48 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-          key: ${{ runner.os }}-${{ matrix.target }}-9.6.6-plustan-${{ hashFiles('cabal.project.freeze') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-${{ matrix.ghc }}-plustan-${{ hashFiles('cabal.project.freeze') }}
 
       - name: Build plustan binary
         run: |
-          mkdir dist
+          mkdir -p dist
           cabal install exe:plustan --install-method=copy --overwrite-policy=always --installdir=dist
 
-      - name: Upload plustan canonical asset
+      - name: Upload plustan asset
         run: |
-          cp "./dist/${{ matrix.binary }}" "./dist/plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}${{ matrix.ext }}"
-          gh release upload ${{ github.ref_name }} "./dist/plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}${{ matrix.ext }}"
+          ASSET="plustan-${{ steps.tag.outputs.tag }}-${{ matrix.target }}-ghc${{ matrix.ghc }}${{ matrix.ext }}"
+          cp "./dist/plustan${{ matrix.ext }}" "./dist/${ASSET}"
+          gh release upload ${{ github.ref_name }} "./dist/${ASSET}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  promote_release:
+    # Publish (un-draft) the release once the build matrix has finished.
+    # `if: always()` means a failed Windows/GHC leg never blocks shipping the
+    # binaries that did build — the release still goes live and becomes the one
+    # the extension's releases/latest lookup resolves to.
+    needs: [build_plustan_canonical]
+    if: always()
+    name: Promote release to latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Publish release (only if binaries were uploaded)
+        run: |
+          # `if: always()` above means we run even when some build legs failed,
+          # so one bad GHC/OS leg never blocks shipping the rest. But never
+          # promote an EMPTY release to `--latest`: that would point every
+          # user's auto-download at a release with no binaries. Require at
+          # least one uploaded asset before un-drafting.
+          COUNT=$(gh release view ${{ github.ref_name }} --json assets --jq '.assets | length')
+          echo "Uploaded assets: ${COUNT}"
+          if [ "${COUNT}" -gt 0 ]; then
+            gh release edit ${{ github.ref_name }} --draft=false --latest
+          else
+            echo "No assets uploaded — leaving release as draft." >&2
+            exit 1
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/stan.cabal
+++ b/stan.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                stan
-version:             0.2.1.0
+version:             0.2.2.0
 synopsis:            Haskell STatic ANalyser
 description:
     Stan is a Haskell __ST__atic __AN__alysis CLI tool.

--- a/vscode-plustan/MARKETPLACE.md
+++ b/vscode-plustan/MARKETPLACE.md
@@ -14,7 +14,7 @@
 
 - The `plustan` binary built from [input-output-hk/plu-stan](https://github.com/input-output-hk/plu-stan)
 - A Haskell workspace compiled with `.hie`/`.hi` artifacts (Plu-Stan will trigger a build automatically if needed)
-- GHC 9.6.6+ and the Cardano system libraries (`secp256k1`, `sodium`, `blst`)
+- A GHC the extension ships a prebuilt binary for (currently 9.6.7, 9.8.4, 9.10.3, 9.12.2). The `plustan` binary reads `.hie` files, whose format is locked to the **exact** GHC version that produced them, so the extension auto-downloads the binary matching your project's GHC. If your project uses a different GHC, build `plustan` with that GHC and set `plustan.binaryPath`.
 
 ## Getting Started
 

--- a/vscode-plustan/package-lock.json
+++ b/vscode-plustan/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-plustan",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-plustan",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/node": "^20.14.10",

--- a/vscode-plustan/package.json
+++ b/vscode-plustan/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-plustan",
   "displayName": "Plu-Stan",
   "description": "Security and performance static analysis for Cardano smart contracts written in Plinth.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "icon": "media/logo.png",
   "publisher": "IOG",
   "license": "MPL-2.0",

--- a/vscode-plustan/src/downloadManager.ts
+++ b/vscode-plustan/src/downloadManager.ts
@@ -4,25 +4,105 @@ import * as path from "node:path";
 import * as vscode from "vscode";
 
 const GITHUB_API_LATEST = "https://api.github.com/repos/input-output-hk/plu-stan/releases/latest";
-const CACHED_BINARY_KEY = "plustan.cachedBinaryPath";
-const CACHED_VERSION_KEY = "plustan.cachedVersion";
+// Map of GHC version -> { path, version } for binaries we've downloaded.
+// stan reads .hie files whose format is locked to the exact GHC version, so we
+// cache (and download) one binary per GHC rather than a single global one.
+const CACHED_BINARIES_KEY = "plustan.cachedBinaries";
 
-type Platform = "linux-x64" | "darwin-arm64";
+type Platform = "linux-x64" | "darwin-arm64" | "windows-x64";
+
+interface CachedBinary {
+  path: string;
+  version: string;
+}
+type CacheMap = Record<string, CachedBinary>;
 
 function detectPlatform(): Platform | null {
   const { arch, platform } = process;
   if (platform === "linux" && arch === "x64") return "linux-x64";
   if (platform === "darwin") return "darwin-arm64"; // Rosetta runs it on Intel too
+  if (platform === "win32" && arch === "x64") return "windows-x64";
   return null;
 }
 
-function assetName(version: string, platform: Platform): string {
-  return `plustan-${version}-${platform}`;
+function platformExt(platform: Platform): string {
+  return platform === "windows-x64" ? ".exe" : "";
+}
+
+function assetName(version: string, platform: Platform, ghc: string): string {
+  return `plustan-${version}-${platform}-ghc${ghc}${platformExt(platform)}`;
+}
+
+/**
+ * Detect the GHC version a project's .hie files were built with.
+ *
+ * stan consumes .hie files, and their on-disk format is locked to the exact
+ * GHC version that produced them — a binary built with a different GHC panics
+ * with `readHieFile: hie file versions`. Every .hie file begins with a
+ * plaintext header like `HIE9063\n9.6.3\n`, so we read the version straight
+ * from the same artifact the binary will read. That is exactly the GHC the
+ * downloaded binary must match.
+ */
+export function detectProjectGhc(hieDir: string, projectDir: string): string | null {
+  const absHieDir = path.isAbsolute(hieDir) ? hieDir : path.join(projectDir, hieDir);
+  const hieFile = findFirstHieFile(absHieDir);
+  if (!hieFile) return null;
+  try {
+    const fd = fs.openSync(hieFile, "r");
+    try {
+      const buf = Buffer.alloc(64);
+      fs.readSync(fd, buf, 0, 64, 0);
+      const header = buf.toString("latin1");
+      const match = header.match(/^HIE\d+\s+([0-9]+(?:\.[0-9]+)+)/);
+      return match ? match[1] : null;
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return null;
+  }
+}
+
+function findFirstHieFile(dir: string): string | null {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.endsWith(".hie")) {
+      return path.join(dir, entry.name);
+    }
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const found = findFirstHieFile(path.join(dir, entry.name));
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
 }
 
 interface GitHubRelease {
   tag_name: string;
   assets: Array<{ name: string; browser_download_url: string }>;
+}
+
+/** GHC versions a release ships a binary for on the given platform. */
+function availableGhcsFor(release: GitHubRelease, platform: Platform): string[] {
+  const ext = platformExt(platform).replace(".", "\\.");
+  const re = new RegExp(`^plustan-.+-${platform}-ghc([0-9]+(?:\\.[0-9]+)+)${ext}$`);
+  return release.assets
+    .map((a) => a.name.match(re))
+    .filter((m): m is RegExpMatchArray => m !== null)
+    .map((m) => m[1]);
+}
+
+function getCacheMap(globalState: vscode.Memento): CacheMap {
+  return globalState.get<CacheMap>(CACHED_BINARIES_KEY, {});
 }
 
 function fetchJson(url: string): Promise<unknown> {
@@ -81,17 +161,21 @@ function downloadFile(
   });
 }
 
-export function getCachedBinaryPath(globalState: vscode.Memento): string | undefined {
-  const cached = globalState.get<string>(CACHED_BINARY_KEY);
-  if (cached && fs.existsSync(cached)) {
-    return cached;
+export function getCachedBinaryPath(globalState: vscode.Memento, ghc: string | null): string | undefined {
+  if (!ghc) {
+    return undefined;
+  }
+  const entry = getCacheMap(globalState)[ghc];
+  if (entry && fs.existsSync(entry.path)) {
+    return entry.path;
   }
   return undefined;
 }
 
 export async function offerDownload(
   context: vscode.ExtensionContext,
-  output: vscode.OutputChannel
+  output: vscode.OutputChannel,
+  ghc: string | null
 ): Promise<string | undefined> {
   const platform = detectPlatform();
   if (!platform) {
@@ -113,17 +197,26 @@ export async function offerDownload(
     return undefined;
   }
 
-  return downloadLatest(context, output, platform);
+  return downloadLatest(context, output, ghc, platform);
 }
 
 export async function downloadLatest(
   context: vscode.ExtensionContext,
   output: vscode.OutputChannel,
+  ghc: string | null,
   platform?: Platform
 ): Promise<string | undefined> {
   const resolved = platform ?? detectPlatform();
   if (!resolved) {
     vscode.window.showErrorMessage("Plu-Stan: auto-download is not supported on this platform/architecture.");
+    return undefined;
+  }
+
+  if (!ghc) {
+    vscode.window.showErrorMessage(
+      "Plu-Stan: couldn't detect your project's GHC version (no .hie files found). " +
+      "Build your project first, or set `plustan.binaryPath` to a plustan you built yourself."
+    );
     return undefined;
   }
 
@@ -134,13 +227,18 @@ export async function downloadLatest(
         output.appendLine("Plu-Stan: fetching latest release info from GitHub...");
         const release = await fetchJson(GITHUB_API_LATEST) as GitHubRelease;
         const version = release.tag_name.replace(/^v/, "");
-        const name = assetName(version, resolved);
+        const name = assetName(version, resolved, ghc);
         const asset = release.assets.find((a) => a.name === name);
 
         if (!asset) {
+          const available = availableGhcsFor(release, resolved);
           throw new Error(
-            `No pre-built binary found for ${resolved} in release ${release.tag_name}. ` +
-            `Expected asset: ${name}. You can set plustan.binaryPath manually instead.`
+            `No prebuilt plustan for GHC ${ghc} on ${resolved} in release ${release.tag_name}. ` +
+            (available.length
+              ? `That release ships binaries for GHC: ${available.join(", ")}. `
+              : `That release ships no ${resolved} binaries. `) +
+            `Rebuild your project with one of those GHC versions, or build plustan with GHC ${ghc} ` +
+            `and point \`plustan.binaryPath\` at it.`
           );
         }
 
@@ -149,18 +247,22 @@ export async function downloadLatest(
           fs.mkdirSync(storageDir, { recursive: true });
         }
 
-        const binaryPath = path.join(storageDir, "plustan");
+        const ext = platformExt(resolved);
+        const binaryPath = path.join(storageDir, `plustan-ghc${ghc}${ext}`);
 
         output.appendLine(`Plu-Stan: downloading ${name}...`);
         await downloadFile(asset.browser_download_url, binaryPath, token);
 
-        fs.chmodSync(binaryPath, 0o755);
+        if (process.platform !== "win32") {
+          fs.chmodSync(binaryPath, 0o755);
+        }
 
-        await context.globalState.update(CACHED_BINARY_KEY, binaryPath);
-        await context.globalState.update(CACHED_VERSION_KEY, version);
+        const cache = getCacheMap(context.globalState);
+        cache[ghc] = { path: binaryPath, version };
+        await context.globalState.update(CACHED_BINARIES_KEY, cache);
 
-        output.appendLine(`Plu-Stan: ${version} installed at ${binaryPath}`);
-        vscode.window.showInformationMessage(`Plu-Stan ${version} installed. Ready to use.`);
+        output.appendLine(`Plu-Stan: ${version} (GHC ${ghc}) installed at ${binaryPath}`);
+        vscode.window.showInformationMessage(`Plu-Stan ${version} (GHC ${ghc}) installed. Ready to use.`);
         return binaryPath;
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -174,7 +276,8 @@ export async function downloadLatest(
 
 export async function checkForUpdates(
   context: vscode.ExtensionContext,
-  output: vscode.OutputChannel
+  output: vscode.OutputChannel,
+  ghc: string | null
 ): Promise<void> {
   const platform = detectPlatform();
   if (!platform) {
@@ -182,25 +285,33 @@ export async function checkForUpdates(
     return;
   }
 
+  if (!ghc) {
+    vscode.window.showWarningMessage(
+      "Plu-Stan: couldn't detect your project's GHC version (no .hie files found). " +
+      "Build your project first so Plu-Stan can fetch a matching binary."
+    );
+    return;
+  }
+
   try {
-    output.appendLine("Plu-Stan: checking for updates...");
+    output.appendLine(`Plu-Stan: checking for updates (GHC ${ghc})...`);
     const release = await fetchJson(GITHUB_API_LATEST) as GitHubRelease;
     const latestVersion = release.tag_name.replace(/^v/, "");
-    const cachedVersion = context.globalState.get<string>(CACHED_VERSION_KEY);
+    const cachedVersion = getCacheMap(context.globalState)[ghc]?.version;
 
     if (cachedVersion === latestVersion) {
-      vscode.window.showInformationMessage(`Plu-Stan: already up to date (${latestVersion}).`);
+      vscode.window.showInformationMessage(`Plu-Stan: already up to date (${latestVersion}, GHC ${ghc}).`);
       return;
     }
 
     const label = cachedVersion ? `Update to ${latestVersion}` : `Download ${latestVersion}`;
     const detail = cachedVersion
-      ? `Plu-Stan ${latestVersion} is available (installed: ${cachedVersion}).`
-      : `Plu-Stan ${latestVersion} is available.`;
+      ? `Plu-Stan ${latestVersion} is available for GHC ${ghc} (installed: ${cachedVersion}).`
+      : `Plu-Stan ${latestVersion} is available for GHC ${ghc}.`;
 
     const choice = await vscode.window.showInformationMessage(detail, label, "Later");
     if (choice === label) {
-      await downloadLatest(context, output, platform);
+      await downloadLatest(context, output, ghc, platform);
     }
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);

--- a/vscode-plustan/src/extension.ts
+++ b/vscode-plustan/src/extension.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { spawn } from "node:child_process";
 import * as vscode from "vscode";
-import { getCachedBinaryPath, offerDownload, checkForUpdates } from "./downloadManager";
+import { getCachedBinaryPath, offerDownload, checkForUpdates, detectProjectGhc } from "./downloadManager";
 
 type AnnotationSource = "hi" | "source" | "both";
 type RunScope = "all" | "module";
@@ -174,7 +174,8 @@ export function activate(context: vscode.ExtensionContext): void {
   const resolveSettings = (folder: vscode.WorkspaceFolder): PluStanSettings => {
     const settings = readSettings(folder);
     if (!settings.binaryPath) {
-      const cached = getCachedBinaryPath(context.globalState);
+      const ghc = detectProjectGhc(settings.hieDir, settings.projectDir);
+      const cached = getCachedBinaryPath(context.globalState, ghc);
       if (cached) return { ...settings, binaryPath: cached };
     }
     return settings;
@@ -182,7 +183,11 @@ export function activate(context: vscode.ExtensionContext): void {
 
   const isEffectivelyConfigured = (folder: vscode.WorkspaceFolder): boolean => {
     const settings = readSettings(folder);
-    return hasConfiguredBinaryPath(settings) || getCachedBinaryPath(context.globalState) !== undefined;
+    if (hasConfiguredBinaryPath(settings)) {
+      return true;
+    }
+    const ghc = detectProjectGhc(settings.hieDir, settings.projectDir);
+    return getCachedBinaryPath(context.globalState, ghc) !== undefined;
   };
 
   context.subscriptions.push(output, diagnostics);
@@ -290,7 +295,8 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(
     vscode.commands.registerCommand("plustan.checkForUpdates", async () => {
-      await checkForUpdates(context, output);
+      const ghc = detectGhcForActiveFolder();
+      await checkForUpdates(context, output, ghc);
       try {
         const folder = getWorkspaceFolder();
         provider.setBinaryConfigured(isEffectivelyConfigured(folder));
@@ -317,7 +323,8 @@ export function activate(context: vscode.ExtensionContext): void {
     const configured = isEffectivelyConfigured(folder);
     provider.setBinaryConfigured(configured);
     if (!configured) {
-      void offerDownload(context, output).then((downloadedPath) => {
+      const ghc = detectProjectGhc(readSettings(folder).hieDir, readSettings(folder).projectDir);
+      void offerDownload(context, output, ghc).then((downloadedPath) => {
         if (downloadedPath) {
           provider.setBinaryConfigured(true);
         }
@@ -483,6 +490,15 @@ function getWorkspaceFolder(): vscode.WorkspaceFolder {
   return active ?? folders[0];
 }
 
+/** Best-effort GHC version of the active workspace folder's .hie files. */
+function detectGhcForActiveFolder(): string | null {
+  try {
+    const settings = readSettings(getWorkspaceFolder());
+    return detectProjectGhc(settings.hieDir, settings.projectDir);
+  } catch {
+    return null;
+  }
+}
 
 function getWorkspaceFolderOrNotify(): vscode.WorkspaceFolder | undefined {
   try {
@@ -601,11 +617,14 @@ async function runPluStanJson<T>(
   try {
     parsed = parseJsonFromOutput(stdout);
   } catch (error) {
-    const exitSuffix = exitCode !== 0 ? `\nExit code: ${exitCode}` : "";
-    throw new Error(
-      `Failed to parse plustan JSON output: ${formatError(error)}${exitSuffix}\n` +
-      `stderr:\n${stderr}\nstdout:\n${stdout}`
-    );
+    // The binary produced no usable JSON. Before showing the raw parser error
+    // (which surfaces as the cryptic "Unexpected end of JSON input"), classify
+    // the failure so the message tells the user what to actually do. The most
+    // common cause is a GHC mismatch: stan reads .hie files whose format is
+    // locked to the exact GHC that built them, so a binary built with a
+    // different GHC panics and emits nothing on stdout.
+    output.appendLine(`Plu-Stan: stdout had no parseable JSON (exit ${exitCode}). Parser said: ${formatError(error)}`);
+    throw new Error(describePluStanFailure(stdout, stderr, exitCode));
   }
 
   if (exitCode !== 0) {
@@ -613,6 +632,38 @@ async function runPluStanJson<T>(
   }
 
   return parsed as T;
+}
+
+/** Turn a no-JSON plustan run into an actionable, user-facing message. */
+function describePluStanFailure(stdout: string, stderr: string, exitCode: number): string {
+  const haystack = `${stderr}\n${stdout}`;
+  const ghcMismatch = /hie file versions|readHieFile|built by a different ghc|different ghc/i.test(haystack);
+  const panicked = /panic!|the 'impossible' happened/i.test(haystack);
+
+  if (ghcMismatch) {
+    return (
+      "Plu-Stan couldn't read your project's .hie files: they were built with a different GHC " +
+      "than the plustan binary. Rebuild your project with the GHC the binary targets, or run " +
+      "\"Plu-Stan: Check for Updates\" to fetch a binary matching your project's GHC. " +
+      "(Full output is in the Plu-Stan output channel.)"
+    );
+  }
+
+  if (panicked) {
+    return (
+      `Plu-Stan crashed (exit ${exitCode}) and produced no analysis. ` +
+      "See the Plu-Stan output channel for the full crash log."
+    );
+  }
+
+  const noOutput = stdout.trim().length === 0;
+  return (
+    `Plu-Stan produced no JSON output (exit ${exitCode}). ` +
+    (noOutput
+      ? "The binary wrote nothing to stdout — it likely failed before analysis (e.g. an outdated or incompatible binary, or a build error). "
+      : "The output wasn't valid JSON. ") +
+    "See the Plu-Stan output channel for details; try \"Plu-Stan: Check for Updates\" if the binary may be outdated."
+  );
 }
 
 function parseJsonFromOutput(stdout: string): unknown {


### PR DESCRIPTION
Foundational PR for the multi-GHC distribution work. Gives the release pipeline + extension a way to ship and pick a plu-stan binary matching the user's project GHC, instead of a single binary that panics on a `.hie` version mismatch and surfaces a cryptic "Unexpected end of JSON input".

## Distribution (`release.yml`)
- Build an `os × ghc` matrix (linux-x64, darwin-arm64, windows-x64 × GHC 9.6.7/9.8.4/9.10.3/9.12.2), naming assets `plustan-<ver>-<platform>-ghc<ghc>[.exe]`.
- `fail-fast: false` so one bad leg doesn't block the rest; a `promote_release` job un-drafts to `--latest` only when assets were actually uploaded.
- Adds the native crypto system deps (libsodium/secp256k1/blst) needed by the build.

## Extension (`vscode-plustan`)
- Detect the project's GHC from the `.hie` header, download the matching asset, cache per GHC. On no match, report the available GHCs + how to proceed.
- Classify no-JSON runs (GHC mismatch / panic / empty output) into an actionable message.
- Version bumps.

## Where this sits in the chain
```
#52  fix/hie-version-tolerance ─► main        (reader tolerates any patch in a GHC minor series)
this ► fix/plustan-multi-ghc-distribution ─► main
  └ #53  fix/ghc-series-release-matrix ─► this branch
```
- **#53** stacks on this branch and evolves it from **per-patch** to **per-minor-series**: trims the matrix to the two series PlutusTx actually supports (9.6 + 9.12), and makes the extension match/cache/name binaries by series.
- **#52** is the correctness prerequisite for that per-series model (one binary must read every patch in its series). Recommended merge order: **#52 → this (+#53) → main**.

## Heads-up for review
`main` has advanced since this branch was cut, so it likely needs a rebase before merge (the version bumps here — stan 0.2.1→0.2.2, ext 0.1.0→0.2.0 — are already behind `main`). Worth reconciling with #53's matrix trim in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)