### PR TITLE
fix(release): ship one binary per GHC minor series, not per patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,16 +29,21 @@ jobs:
       # the release regardless (see promote_release).
       fail-fast: false
       matrix:
-        # stan reads .hie files, whose on-disk format is locked to the exact
-        # GHC PATCH version that produced them (the binary panics with
-        # "readHieFile: hie file versions" otherwise). So we ship one binary
-        # *per GHC patch*, and the extension downloads the one matching the
-        # user's project GHC. The set below is what CI proves green on all
-        # three OSes; expand it to cover the GHC patches your users run.
+        # stan reads .hie files. GHC bumps the .hie format version on every
+        # patch release, but the on-disk format is stable *within* a minor
+        # series, and the binary now reads any patch in its series (see
+        # Stan.Hie.Compat904, merged in #52). So we ship one binary *per minor
+        # series* and the extension picks the one matching the user's project
+        # GHC series. Future patch releases (e.g. 9.6.8, 9.12.3) need no new
+        # build — an existing series binary already reads them.
         #
-        # `os` and `ghc` are BOTH base dimensions -> the full 3x5 = 15 jobs.
+        # PlutusTx (plutus-tx-plugin) only builds on GHC 9.6 and 9.12, and a
+        # Cabal project is single-GHC, so every .hie a PlutusTx project emits is
+        # 9.6.x or 9.12.x. Hence exactly these two series, latest patch each.
+        #
+        # `os` and `ghc` are BOTH base dimensions -> the full 3x2 = 6 jobs.
         # The `include` block only attaches target/ext to each `os` value.
-        ghc: ["9.6.3", "9.6.7", "9.8.4", "9.10.3", "9.12.2"]
+        ghc: ["9.6.7", "9.12.2"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - { os: ubuntu-latest,  target: linux-x64,    ext: "" }
@@ -90,7 +95,10 @@ jobs:
           mkdir -p dist
           VERSION="${GITHUB_REF_NAME#v}"   # tag v0.2.4.0 -> 0.2.4.0
           BIN=$(cabal list-bin exe:plustan)
-          ASSET="plustan-${VERSION}-${{ matrix.target }}-ghc${{ matrix.ghc }}${{ matrix.ext }}"
+          # Name the asset by GHC minor series (9.6.7 -> 9.6): one binary reads
+          # every patch in its series, and the extension matches on the series.
+          GHC_SERIES=$(echo "${{ matrix.ghc }}" | cut -d. -f1,2)
+          ASSET="plustan-${VERSION}-${{ matrix.target }}-ghc${GHC_SERIES}${{ matrix.ext }}"
           cp "$BIN" "./dist/${ASSET}"
           gh release upload "${GITHUB_REF_NAME}" "./dist/${ASSET}"
         env:

--- a/vscode-plustan/src/downloadManager.ts
+++ b/vscode-plustan/src/downloadManager.ts
@@ -5,9 +5,10 @@ import { execFile } from "node:child_process";
 import * as vscode from "vscode";
 
 const GITHUB_API_LATEST = "https://api.github.com/repos/input-output-hk/plu-stan/releases/latest";
-// Map of GHC version -> { path, version } for binaries we've downloaded.
-// stan reads .hie files whose format is locked to the exact GHC version, so we
-// cache (and download) one binary per GHC rather than a single global one.
+// Map of GHC major.minor series -> { path, version } for binaries we've
+// downloaded. A plustan build reads every .hie file produced by its GHC series
+// (patch releases share the on-disk format), so we cache and download one
+// binary per series rather than per patch or a single global one.
 const CACHED_BINARIES_KEY = "plustan.cachedBinaries";
 
 type Platform = "linux-x64" | "darwin-arm64" | "windows-x64";
@@ -30,19 +31,32 @@ function platformExt(platform: Platform): string {
   return platform === "windows-x64" ? ".exe" : "";
 }
 
+/**
+ * The GHC major.minor series of a version string, e.g. "9.6.3" -> "9.6".
+ *
+ * A single plustan build reads every .hie file produced by its GHC series: GHC
+ * bumps the .hie format version on every patch release, but the on-disk format
+ * only changes across minor series, and plustan now reads any patch in its
+ * series (Stan.Hie.Compat904). So binaries are shipped, matched and cached per
+ * series, not per patch.
+ */
+function ghcSeries(ghc: string): string {
+  return ghc.split(".").slice(0, 2).join(".");
+}
+
 function assetName(version: string, platform: Platform, ghc: string): string {
-  return `plustan-${version}-${platform}-ghc${ghc}${platformExt(platform)}`;
+  return `plustan-${version}-${platform}-ghc${ghcSeries(ghc)}${platformExt(platform)}`;
 }
 
 /**
  * Detect the GHC version a project's .hie files were built with.
  *
- * stan consumes .hie files, and their on-disk format is locked to the exact
- * GHC version that produced them — a binary built with a different GHC panics
- * with `readHieFile: hie file versions`. Every .hie file begins with a
- * plaintext header like `HIE9063\n9.6.3\n`, so we read the version straight
- * from the same artifact the binary will read. That is exactly the GHC the
- * downloaded binary must match.
+ * stan consumes .hie files, whose on-disk format is tied to the GHC major.minor
+ * series that produced them: patch releases within a series share a format, but
+ * a binary from a different series can't read them. Every .hie file begins with
+ * a plaintext header like `HIE9063\n9.6.3\n`, so we read the full version
+ * straight from the same artifact the binary will read; the binary is then
+ * matched by its series (see `ghcSeries`).
  */
 export function detectProjectGhc(hieDir: string, projectDir: string): string | null {
   const absHieDir = path.isAbsolute(hieDir) ? hieDir : path.join(projectDir, hieDir);
@@ -92,7 +106,7 @@ interface GitHubRelease {
   assets: Array<{ name: string; browser_download_url: string }>;
 }
 
-/** GHC versions a release ships a binary for on the given platform. */
+/** GHC minor series a release ships a binary for on the given platform. */
 function availableGhcsFor(release: GitHubRelease, platform: Platform): string[] {
   const ext = platformExt(platform).replace(".", "\\.");
   const re = new RegExp(`^plustan-.+-${platform}-ghc([0-9]+(?:\\.[0-9]+)+)${ext}$`);
@@ -189,7 +203,7 @@ export function getCachedBinaryPath(globalState: vscode.Memento, ghc: string | n
   if (!ghc) {
     return undefined;
   }
-  const entry = getCacheMap(globalState)[ghc];
+  const entry = getCacheMap(globalState)[ghcSeries(ghc)];
   if (entry && fs.existsSync(entry.path)) {
     return entry.path;
   }
@@ -257,13 +271,13 @@ export async function downloadLatest(
         if (!asset) {
           const available = availableGhcsFor(release, resolved);
           throw new Error(
-            `No prebuilt plustan for GHC ${ghc} on ${resolved} in release ${release.tag_name}. ` +
+            `No prebuilt plustan for GHC ${ghc} (series ${ghcSeries(ghc)}) on ${resolved} in release ${release.tag_name}. ` +
             (available.length
-              ? `That release ships binaries for GHC: ${available.join(", ")}. `
+              ? `That release ships binaries for GHC series: ${available.join(", ")}. `
               : `That release ships no ${resolved} binaries. `) +
             `GHC ${ghc} was detected from your project's .hie files, not from your installed ` +
             `toolchain — switching GHC (e.g. with ghcup) has no effect until you rebuild the ` +
-            `project and regenerate them. Rebuild with one of the shipped GHC versions ` +
+            `project and regenerate them. Rebuild with a GHC from one of the shipped series ` +
             `(clearing stale .hie files first), or build plustan with GHC ${ghc} yourself and ` +
             `point \`plustan.binaryPath\` at it.`
           );
@@ -275,7 +289,7 @@ export async function downloadLatest(
         }
 
         const ext = platformExt(resolved);
-        const binaryPath = path.join(storageDir, `plustan-ghc${ghc}${ext}`);
+        const binaryPath = path.join(storageDir, `plustan-ghc${ghcSeries(ghc)}${ext}`);
 
         output.appendLine(`Plu-Stan: downloading ${name}...`);
         await downloadFile(asset.browser_download_url, binaryPath, token);
@@ -288,7 +302,7 @@ export async function downloadLatest(
         }
 
         const cache = getCacheMap(context.globalState);
-        cache[ghc] = { path: binaryPath, version };
+        cache[ghcSeries(ghc)] = { path: binaryPath, version };
         await context.globalState.update(CACHED_BINARIES_KEY, cache);
 
         output.appendLine(`Plu-Stan: ${version} (GHC ${ghc}) installed at ${binaryPath}`);
@@ -339,7 +353,7 @@ export async function checkForUpdates(
     output.appendLine(`Plu-Stan: checking for updates (GHC ${ghc})...`);
     const release = await fetchJson(GITHUB_API_LATEST) as GitHubRelease;
     const latestVersion = release.tag_name.replace(/^v/, "");
-    const cachedVersion = getCacheMap(context.globalState)[ghc]?.version;
+    const cachedVersion = getCacheMap(context.globalState)[ghcSeries(ghc)]?.version;
 
     if (cachedVersion === latestVersion) {
       if (!quiet) {


### PR DESCRIPTION
Rebuilds the matrix trim + series-based selection **against current `main`** (the earlier #53 targeted the already-merged `fix/plustan-multi-ghc-distribution` branch, so it couldn't land). Supersedes **#53**.

## Why this is safe now
**#52** (reader tolerates any patch within a GHC minor series) is **already merged to `main`**, so one build per series reads every patch in it. And `plutus-tx-plugin` only builds on GHC **9.6** and **9.12**; a Cabal project is single-GHC, so every `.hie` a PlutusTx project emits is 9.6.x or 9.12.x.

## Changes
**`release.yml`**
- Matrix `9.6.3, 9.6.7, 9.8.4, 9.10.3, 9.12.2` → **`9.6.7, 9.12.2`** (3×5=15 → 3×2=6 jobs). Drops 9.8/9.10 (no PlutusTx project emits their `.hie`) and the duplicate 9.6 patch. Future patches (9.6.8, 9.12.3) need **no new build**.
- Assets named by **series** (`plustan-<ver>-<target>-ghc9.6`).

**`downloadManager.ts`**
- New `ghcSeries()`; binaries are **matched, cached and named by GHC major.minor series**. A project on 9.6.5 now resolves to the `ghc9.6` binary instead of failing an exact-version lookup. `detectProjectGhc` still returns the full version for messages.

## Verification
- `tsc -p ./` clean.
- `release.yml` parses as valid YAML.
- Name agreement: `ghcSeries("9.6.5") === "9.6"` and `echo 9.6.7 | cut -d. -f1,2 === "9.6"` — the extension's computed asset name equals the one CI uploads.

## Follow-ups
- **Close #53** (superseded by this).
- Optional: bump the extension version on release (left out to avoid churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)