### PR TITLE
fix(ext): robust monorepo finding-path resolution (re-target of #54 to main)

### DIFF
--- a/vscode-plustan/MARKETPLACE.md
+++ b/vscode-plustan/MARKETPLACE.md
@@ -17,7 +17,7 @@
 
 - The `plustan` binary built from [input-output-hk/plu-stan](https://github.com/input-output-hk/plu-stan). Extension 0.3.x requires `plustan` >= 0.2.5.0; the extension checks this automatically via a `plustan capabilities` handshake and prompts you to update if there's a mismatch.
 - A Haskell workspace compiled with `.hie`/`.hi` artifacts (Plu-Stan will trigger a build automatically if needed)
-- A GHC the extension ships a prebuilt binary for. The `plustan` binary reads `.hie` files, whose format is locked to the **exact** GHC version that produced them, so the extension auto-downloads the binary matching your project's GHC. If your project uses a different GHC, build `plustan` with that GHC and set `plustan.binaryPath`.
+- A GHC the extension ships a prebuilt binary for. The `plustan` binary reads `.hie` files, whose on-disk format is tied to the GHC **major.minor series** that produced them — patch releases within a series share the format, so one binary handles any patch of its series (e.g. a 9.6 build reads any 9.6.x project). The extension fetches the binary matching your project's GHC. If your project's GHC series isn't shipped, build `plustan` with that GHC and set `plustan.binaryPath`.
 
 ## Getting Started
 
@@ -30,6 +30,8 @@
    ```
 3. In the **Findings** view, click **Start Review** (▶), pick the modules to review (or accept all), and work the findings tree: click through to each issue, read the explanation, fix it or dismiss it.
 4. Click **End Review** when you're done — it stops auto re-runs and logs a fixed/open/dismissed summary.
+
+> **Monorepo / multi-package projects:** if your on-chain package lives in a subdirectory (e.g. `onchain/`), point `plustan.hieDir` at that package's `.hie` directory (e.g. `onchain/.hie`), or set `plustan.projectDir` to the package. Plu-Stan resolves each finding against the package that produced it, so either works.
 
 ## Commands
 
@@ -54,8 +56,8 @@
 | Setting | Default | Description |
 |---|---|---|
 | `plustan.binaryPath` | `""` | Path to the `plustan` executable. Supports a leading `${workspaceFolder}` token. Leave empty to let the extension manage a downloaded binary |
-| `plustan.projectDir` | `""` | Project directory. Defaults to the active workspace folder |
-| `plustan.hieDir` | `".hie"` | Directory containing `.hie`/`.hi` files, relative to `projectDir` |
+| `plustan.projectDir` | `""` | Directory Plu-Stan runs the analyzer in. Defaults to the workspace folder; usually only needed to point at a package subdirectory in a monorepo |
+| `plustan.hieDir` | `".hie"` | Directory containing `.hie`/`.hi` files. Relative to `projectDir`, or an absolute path |
 | `plustan.extraArgs` | `[]` | Additional CLI arguments appended to `plustan analyze` runs |
 | `plustan.showOutputChannel` | `true` | Automatically show the output channel when running commands |
 

--- a/vscode-plustan/package-lock.json
+++ b/vscode-plustan/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-plustan",
-  "version": "0.2.2",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-plustan",
-      "version": "0.2.2",
+      "version": "0.3.2",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/vscode-plustan/package.json
+++ b/vscode-plustan/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-plustan",
   "displayName": "Plu-Stan",
   "description": "Security and performance static analysis for Cardano smart contracts written in Plinth.",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "icon": "media/logo.png",
   "publisher": "IOG",
   "license": "MPL-2.0",

--- a/vscode-plustan/src/core/paths.test.ts
+++ b/vscode-plustan/src/core/paths.test.ts
@@ -1,0 +1,56 @@
+import * as assert from "node:assert";
+import { resolveFindingPath } from "./paths";
+
+// A fake `exists` that only knows about the paths we say are on disk.
+const existsIn = (present: string[]) => (p: string) => present.includes(p);
+
+describe("resolveFindingPath", () => {
+  const file = "src/Cardano/Djed/OnChain/CustomRatio.hs";
+
+  it("resolves the real-world broken config: projectDir unset, hieDir under a package subdir", () => {
+    // The exact stablecoin case: projectDir defaults to the workspace root and
+    // hieDir points at <workspaceRoot>/onchain/.hie. The file lives under
+    // onchain/, so it must resolve via the dirname(hieDir) candidate.
+    const ctx = {
+      projectDir: "/ws",
+      hieDir: "/ws/onchain/.hie",
+      workspaceRoot: "/ws"
+    };
+    const resolved = resolveFindingPath(file, ctx, existsIn(["/ws/onchain/" + file]));
+    assert.strictEqual(resolved, "/ws/onchain/src/Cardano/Djed/OnChain/CustomRatio.hs");
+  });
+
+  it("resolves the intended config: projectDir set to the package", () => {
+    const ctx = { projectDir: "/ws/onchain", hieDir: ".hie", workspaceRoot: "/ws" };
+    const resolved = resolveFindingPath(file, ctx, existsIn(["/ws/onchain/" + file]));
+    assert.strictEqual(resolved, "/ws/onchain/src/Cardano/Djed/OnChain/CustomRatio.hs");
+  });
+
+  it("resolves a single-package project where package == workspace root", () => {
+    const ctx = { projectDir: "/ws", hieDir: ".hie", workspaceRoot: "/ws" };
+    const resolved = resolveFindingPath(file, ctx, existsIn(["/ws/" + file]));
+    assert.strictEqual(resolved, "/ws/src/Cardano/Djed/OnChain/CustomRatio.hs");
+  });
+
+  it("returns an absolute file path unchanged", () => {
+    const abs = "/somewhere/CustomRatio.hs";
+    const ctx = { projectDir: "/ws/onchain", hieDir: ".hie", workspaceRoot: "/ws" };
+    assert.strictEqual(resolveFindingPath(abs, ctx, existsIn([])), abs);
+  });
+
+  it("prefers projectDir when the file exists under multiple bases", () => {
+    const ctx = { projectDir: "/ws/onchain", hieDir: "/ws/onchain/.hie", workspaceRoot: "/ws" };
+    const resolved = resolveFindingPath(
+      file,
+      ctx,
+      existsIn(["/ws/onchain/" + file, "/ws/" + file])
+    );
+    assert.strictEqual(resolved, "/ws/onchain/src/Cardano/Djed/OnChain/CustomRatio.hs");
+  });
+
+  it("falls back to projectDir when nothing exists on disk", () => {
+    const ctx = { projectDir: "/ws/onchain", hieDir: ".hie", workspaceRoot: "/ws" };
+    const resolved = resolveFindingPath(file, ctx, existsIn([]));
+    assert.strictEqual(resolved, "/ws/onchain/src/Cardano/Djed/OnChain/CustomRatio.hs");
+  });
+});

--- a/vscode-plustan/src/core/paths.ts
+++ b/vscode-plustan/src/core/paths.ts
@@ -1,0 +1,60 @@
+import * as path from "node:path";
+import * as fs from "node:fs";
+
+export interface FindingPathContext {
+  /** Directory the analyzer runs plu-stan in (cwd). May be the package dir or the workspace root. */
+  projectDir: string;
+  /** `hieDir` from settings; relative (to projectDir) or absolute. */
+  hieDir: string;
+  /** The VS Code workspace folder. */
+  workspaceRoot: string;
+}
+
+/**
+ * Resolve a plu-stan finding's `file` — emitted *relative to the package
+ * directory* (e.g. "src/Cardano/Djed/OnChain/Oracle.hs") — to an absolute path.
+ *
+ * The package dir isn't given to us directly, and it need not equal any single
+ * setting: a user may set `projectDir` to the package (then it's projectDir), or
+ * leave `projectDir` at the workspace root and point `hieDir` at <package>/.hie
+ * (then it's dirname(hieDir)). So we try the likely bases in priority order and
+ * return the first whose joined path exists on disk. The existence check makes a
+ * wrong guess harmless — it simply falls through to the next base.
+ *
+ * No ambiguity handling on purpose: in a monorepo each package sits in its own
+ * subdirectory, so a given package-relative path exists under exactly one base.
+ */
+export function resolveFindingPath(
+  file: string,
+  ctx: FindingPathContext,
+  exists: (p: string) => boolean = fs.existsSync
+): string {
+  if (path.isAbsolute(file)) {
+    return file;
+  }
+
+  const absHieDir = path.isAbsolute(ctx.hieDir)
+    ? ctx.hieDir
+    : path.join(ctx.projectDir, ctx.hieDir);
+
+  const bases = dedupe([
+    ctx.projectDir,           // projectDir pointed at the package (intended config)
+    path.dirname(absHieDir),  // package inferred from a <package>/.hie layout
+    ctx.workspaceRoot         // single-package project: package == workspace root
+  ]);
+
+  for (const base of bases) {
+    const candidate = path.join(base, file);
+    if (exists(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Nothing matched on disk; keep the previous behaviour so a "cannot open"
+  // error at least points somewhere sensible.
+  return path.join(ctx.projectDir, file);
+}
+
+function dedupe(xs: string[]): string[] {
+  return xs.filter((x, i) => xs.indexOf(x) === i);
+}

--- a/vscode-plustan/src/diagnostics.ts
+++ b/vscode-plustan/src/diagnostics.ts
@@ -1,4 +1,3 @@
-import * as path from "node:path";
 import * as vscode from "vscode";
 import { InspectionV2 } from "./core/schema";
 import { SessionFinding, SessionState } from "./core/sessionState";
@@ -11,7 +10,7 @@ export interface PluStanDiagnostic extends vscode.Diagnostic {
 export function publishSessionDiagnostics(
   state: SessionState,
   inspections: Map<string, InspectionV2>,
-  workspaceRoot: string,
+  resolveFile: (file: string) => string,
   collection: vscode.DiagnosticCollection
 ): void {
   collection.clear();
@@ -22,7 +21,7 @@ export function publishSessionDiagnostics(
       continue;
     }
     const inspection = inspections.get(finding.inspectionId);
-    const filePath = path.isAbsolute(finding.file) ? finding.file : path.join(workspaceRoot, finding.file);
+    const filePath = resolveFile(finding.file);
     const stalePrefix = finding.status === "stale" ? "(stale) " : "";
     const summary = inspection ? `${inspection.name} — ${inspection.description}` : "";
     const diagnostic: PluStanDiagnostic = new vscode.Diagnostic(

--- a/vscode-plustan/src/extension.ts
+++ b/vscode-plustan/src/extension.ts
@@ -10,6 +10,7 @@ import { FindingDetailProvider } from "./ui/detailPanel";
 import { PluStanStatusBar } from "./ui/statusBar";
 import { DismissCodeActionProvider, publishSessionDiagnostics, toRange } from "./diagnostics";
 import { SessionFinding, initialSessionState, reduceSession } from "./core/sessionState";
+import { resolveFindingPath } from "./core/paths";
 
 // Throttle for the background "newer backend available?" check on activation.
 const LAST_AUTO_UPDATE_CHECK_KEY = "plustan.lastAutoUpdateCheck";
@@ -361,10 +362,19 @@ export function activate(context: vscode.ExtensionContext): void {
   })();
 
   if (folder) {
-    // Capture the resolved root once: `folder` is a const narrowed to defined
-    // here, but that narrowing is not carried into the hoisted openFinding
-    // function declaration below, so read the path eagerly.
-    const workspaceRoot = folder.uri.fsPath;
+    // plu-stan emits finding paths relative to the *package* directory. That is
+    // usually settings.projectDir, but in a monorepo a user may leave projectDir
+    // at the workspace root and only point hieDir at <package>/.hie — so we use a
+    // resolver that tries the likely package roots and picks the one that exists
+    // on disk (see resolveFindingPath). Captured once: the `folder` narrowing is
+    // not carried into the hoisted openFinding declaration below.
+    const findingSettings = readSettings(folder);
+    const findingCtx = {
+      projectDir: findingSettings.projectDir,
+      hieDir: findingSettings.hieDir,
+      workspaceRoot: folder.uri.fsPath
+    };
+    const resolveFile = (file: string): string => resolveFindingPath(file, findingCtx);
     const statusBar = new PluStanStatusBar();
     const findingsTree = new FindingsTreeProvider();
 
@@ -375,7 +385,7 @@ export function activate(context: vscode.ExtensionContext): void {
       context.workspaceState,
       (state, inspections) => {
         findingsTree.setData(state, inspections);
-        publishSessionDiagnostics(state, inspections, workspaceRoot, diagnostics);
+        publishSessionDiagnostics(state, inspections, resolveFile, diagnostics);
       },
       output
     );
@@ -390,10 +400,10 @@ export function activate(context: vscode.ExtensionContext): void {
     controller.restore();
 
     async function openFinding(finding: SessionFinding): Promise<void> {
-      // Use the captured workspaceRoot (definite inside this block); re-deriving
-      // via getWorkspaceFolder() could throw, and this runs void-ed from the
-      // detail panel where a throw would become an unhandled rejection.
-      const filePath = path.isAbsolute(finding.file) ? finding.file : path.join(workspaceRoot, finding.file);
+      // Use the captured resolver (definite inside this block); re-deriving via
+      // getWorkspaceFolder() could throw, and this runs void-ed from the detail
+      // panel where a throw would become an unhandled rejection.
+      const filePath = resolveFile(finding.file);
       const doc = await vscode.workspace.openTextDocument(filePath);
       const editor = await vscode.window.showTextDocument(doc, { preserveFocus: false });
       const range = toRange(finding);
@@ -497,10 +507,16 @@ async function runOneShot(
       reduceSession(initialSessionState, { type: "sessionStarted", startedAt: new Date().toISOString() }),
       { type: "runCompleted", coveredFiles, observations: payload.observations, dismissedFingerprints: [] }
     );
+    const oneShotSettings = readSettings(folder);
     publishSessionDiagnostics(
       oneShot,
       new Map(payload.inspections.map((i) => [i.id, i])),
-      folder.uri.fsPath,
+      // Same package-relative resolution as the session path (see paths.ts).
+      (file) => resolveFindingPath(file, {
+        projectDir: oneShotSettings.projectDir,
+        hieDir: oneShotSettings.hieDir,
+        workspaceRoot: folder.uri.fsPath
+      }),
       diagnostics
     );
 


### PR DESCRIPTION
Re-targets **#54** at `main`. #54 was merged into the cockpit branch (`feature/vscode-review-cockpit`) a few minutes *after* that branch had already merged to `main` via #51 — so its changes never reached `main`. `main` currently ships the cockpit at **0.3.0 without this fix** (`core/paths.ts` is absent).

`main` now contains the cockpit code, so these changes apply cleanly on top.

## What it does
plu-stan emits each finding's `file` relative to the **package** directory. This adds a pure helper `core/paths.ts` `resolveFindingPath` that tries the likely package roots — `projectDir`, `dirname(hieDir)`, `workspaceRoot` — and returns the first that **exists on disk**. So click-to-open and inline diagnostics resolve correctly whether `projectDir` points at the package or the workspace root — in a monorepo (e.g. an `onchain/` subpackage) it works with **no `plustan.projectDir` setting required**. Both the session-diagnostics and `openFinding` paths, plus the legacy one-shot, go through the resolver (`diagnostics.ts` now takes a `resolveFile` function).

Also: corrected marketplace README (GHC major.minor-series wording per #52, monorepo note, `hieDir` absolute / `projectDir` optional) and bumped the extension **0.3.0 → 0.3.2**.

## Verification
- `npm run test:unit` — **55 passing**, including a test that reproduces the exact broken config (projectDir unset, hieDir under a package subdir).
- The compiled resolver run against the real stablecoin tree resolves the finding to the existing `onchain/src/...` file for **both** `projectDir=onchain` and `projectDir=workspace-root`.

## Housekeeping
- Supersedes the stranded #54 (merged into the dead cockpit branch). A `revert-54-*` branch also exists on origin (the cockpit-side backout) — safe to drop.
- This is the version that should be published as the marketplace extension (`0.3.2`, robust — no per-project setting needed), superseding the `0.3.1` that required `plustan.projectDir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)