### PR TITLE
chore(ext): bump 0.3.3 for series-download release

### DIFF
--- a/vscode-plustan/package-lock.json
+++ b/vscode-plustan/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-plustan",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-plustan",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/vscode-plustan/package.json
+++ b/vscode-plustan/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-plustan",
   "displayName": "Plu-Stan",
   "description": "Security and performance static analysis for Cardano smart contracts written in Plinth.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "icon": "media/logo.png",
   "publisher": "IOG",
   "license": "MPL-2.0",


### PR DESCRIPTION
Bumps the extension 0.3.2 -> 0.3.3 so the fixed extension can be published.

**Why:** the published 0.3.2 predates #56's series-based download selection, so it matched exact-patch asset names (`ghc9.6.7`) while releases now ship series assets (`ghc9.6`) — auto-download failed ("No prebuilt plustan for GHC 9.6.7"). `main` already has #56 (series selection) + #58 (path resolver); this only bumps the version so a same-code republish is possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)