### PR TITLE
fix(ci): unbreak the matrix, libsodium install and Windows dogfooding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         cabal: ["3.10"]
+        # 9.4.7 is the floor. exe:plustan reads .hi interface annotations
+        # straight through the modern GHC API, which does not exist in that
+        # shape any earlier: 8.8/8.10 predate the GHC.* module layout wholesale
+        # (no GHC.Iface.Binary, GHC.Platform.Profile, GHC.Types.Name.Cache, ...)
+        # and 9.0/9.2 have incompatible signatures (readBinIface runs in TcRnIf,
+        # initNameCache is pure and takes a UniqSupply). See the note on
+        # exe:plustan in stan.cabal. The release matrix ships 9.6.7 and 9.12.2,
+        # so nothing below 9.4 was ever shipped to users either.
         ghc:
-          - "8.8.4"
-          - "8.10.7"
-          - "9.0.1"
-          - "9.0.2"
-          # 9.2 series from .4 onwards don't seem to work
-          - "9.2.3"
-          # 9.4 series from don't work with Cabal-syntax-3.14.0.0
-          #
-          # See https://github.com/haskell/cabal/issues/10397
           - "9.4.7"
           - "9.4.8"
           # 9.6.3 is in the release matrix (plutus projects commonly pin it),
@@ -40,22 +39,6 @@ jobs:
           - "9.8.4"
           - "9.10.2"
           - "9.12.2"
-
-        exclude:
-          - os: macOS-latest
-            ghc: 8.8.4
-          - os: macOS-latest
-            ghc: 8.10.7
-          - os: macOS-latest
-            ghc: 9.0.1
-          - os: macOS-latest
-            ghc: 9.0.2
-          - os: macOS-latest
-            ghc: 9.2.3
-          - os: macOS-latest
-            ghc: 9.4.1
-          - os: windows-latest
-            ghc: 8.8.4
     steps:
     - uses: actions/checkout@v4
 

--- a/.stan-windows.toml
+++ b/.stan-windows.toml
@@ -1,3 +1,16 @@
+# Windows counterpart of .stan.toml (paths need backslash separators here).
+# Keep the [[remove]] / [[check]] entries in sync with .stan.toml -- the CI
+# "Dogfooding on Windows" step uses this file, so drift makes Windows analyse a
+# different set of modules than Linux/macOS and fail on its own source.
+[[remove]]
+directory = "src\\"
+
+[[remove]]
+directory = "app\\"
+
+[[remove]]
+directory = "test\\"
+
 [[remove]]
 directory = "target\\"
 

--- a/.stan.toml
+++ b/.stan.toml
@@ -1,3 +1,7 @@
+# Keep the [[remove]] / [[check]] entries in sync with .stan-windows.toml,
+# which is the same config with backslash path separators (used by the CI
+# "Dogfooding on Windows" step).
+
 #[[remove]]
 #directory = "target/"
 

--- a/scripts/install-system-deps.sh
+++ b/scripts/install-system-deps.sh
@@ -66,6 +66,18 @@ BLST_VERSION="0.3.11"
 
 WORKDIR="${TMPDIR:-/tmp}/plu-stan-syslibs"
 
+# libsodium's autogen.sh ends by curl-ing fresh config.guess/config.sub from
+# git.savannah.gnu.org over the perfectly good copies its repo already ships.
+# `curl -sL` is silent *and* ignores HTTP status, so when savannah is down the
+# error page itself lands in build-aux/config.sub and configure dies with
+#   configure: error: cannot run /bin/bash ./build-aux/config.sub
+# -- a third-party outage failing our build (savannah was returning 502 on
+# 2026-08-18). autogen.sh honours this variable to skip the refresh, so we
+# always use the committed, pinned scripts. Exported rather than set per-call so
+# any autotools dep added later inherits it; secp256k1's autogen.sh is a plain
+# `autoreconf -if` and simply ignores it.
+export DO_NOT_UPDATE_CONFIG_SCRIPTS=1
+
 # ----------------------------------------------------------------------------
 # Helpers
 # ----------------------------------------------------------------------------
@@ -291,7 +303,8 @@ build_libsodium() {
   clone_ref "$LIBSODIUM_REPO" "$LIBSODIUM_REF" "$dir"
   (
     cd "$dir"
-    ./autogen.sh -s
+    # No -s: autogen.sh takes no arguments, so the flag was always a no-op.
+    ./autogen.sh
     ./configure --prefix="$PREFIX"
     make -j"$JOBS"
     maybe_sudo make install

--- a/stan.cabal
+++ b/stan.cabal
@@ -26,8 +26,14 @@ extra-source-files:  test/.stan-example.toml
                      stack-ghc-9.6.7.yaml
                      stack-ghc-9.8.4.yaml
                      stack.yaml
-tested-with:         GHC == 8.8.4
-                     GHC == 8.10.7
+-- Keep in sync with the `ghc:` matrix in .github/workflows/ci.yml.
+tested-with:         GHC == 9.4.7
+                     GHC == 9.4.8
+                     GHC == 9.6.3
+                     GHC == 9.6.7
+                     GHC == 9.8.4
+                     GHC == 9.10.2
+                     GHC == 9.12.2
 
 source-repository head
   type:                git
@@ -161,7 +167,10 @@ library
   build-depends:       array ^>= 0.5
                      , base64 >= 0.4.1 && < 1.1
                      , blaze-html ^>= 0.9.1
-                     , bytestring >= 0.10 && < 0.13
+                     -- >= 0.11 for Data.ByteString.Char8.(!?), used in
+                     -- Stan.Analysis.Analyser. The GHC floor (9.4.7) ships
+                     -- 0.11.5.2, so this is the bound the code already needed.
+                     , bytestring >= 0.11 && < 0.13
                      , clay >= 0.14 && < 0.17
                      , colourista >= 0.1 && < 0.3
                      , containers >= 0.5 && < 0.9
@@ -201,14 +210,33 @@ executable plustan
   import:              common-options
   hs-source-dirs:      app
   main-is:             PluStan.hs
+  -- Unlike lib:stan, which reaches the GHC API only through the CPP compat
+  -- shims in Stan.Ghc.Compat / Stan.Hie.Compat, PluStan.hs reads .hi interface
+  -- annotations directly and so is tied to the modern GHC API:
+  --
+  --   * GHC 8.8 / 8.10 predate the GHC.* API layout wholesale -- there is no
+  --     GHC.Driver.Session, GHC.Iface.Binary, GHC.Iface.Syntax,
+  --     GHC.Platform.Profile, GHC.Types.Annotations, GHC.Types.Name.Cache or
+  --     GHC.Unit.Module.ModIface to import;
+  --   * GHC 9.0 / 9.2 have the module layout but different signatures:
+  --     readBinIface runs in TcRnIf and takes no Profile/NameCache, and
+  --     initNameCache is pure and takes a UniqSupply rather than a Char.
+  --
+  -- Porting that would mean a second GHC API path for compilers no released
+  -- plustan is ever built with (release.yml ships 9.6.7 and 9.12.2 only), so
+  -- the exe simply drops out below 9.4. CI's floor is 9.4.7, so nothing tested
+  -- hits this; it just turns an old-GHC build into a clean "not buildable"
+  -- rather than a wall of GHC API type errors.
+  if impl(ghc < 9.4)
+    buildable: False
   build-depends:       stan
                      , colourista
                      , containers >= 0.5 && < 0.9
                      , bytestring
                      , directory
                      , filepath
-                     , ghc >= 8.8 && < 9.13
-                     , ghc-boot >= 8.8 && < 9.13
+                     , ghc >= 9.4 && < 9.13
+                     , ghc-boot >= 9.4 && < 9.13
                      , ghc-paths
                      , microaeson ^>= 0.1.0.0
                      , process


### PR DESCRIPTION
The previous commit fixed the `Configure` step, which had been masking every downstream failure. With the matrix finally reaching `Build`, four independent breakages surfaced. Each is fixed here.

1. Raise the CI GHC floor to 9.4.7 (drops 8.8.4, 8.10.7, 9.0.1, 9.0.2, 9.2.3).

   exe:plustan reads .hi interface annotations straight through the modern GHC API and cannot compile any earlier: 8.8/8.10 predate the GHC.* module layout wholesale (verified locally -- GHC 8.10.7 resolves none of GHC.Driver.Session, GHC.Iface.Binary, GHC.Iface.Syntax, GHC.Platform.Profile, GHC.Types.Annotations, GHC.Types.Name.Cache, GHC.Unit.Module.ModIface), and 9.0/9.2 have the layout but incompatible signatures -- readBinIface runs in TcRnIf, initNameCache is pure over a UniqSupply. release.yml only ever shipped 9.6.7 and 9.12.2, so no user was on a pre-9.4 plustan.

   `tested-with` said 8.8.4/8.10.7 and is now synced to the matrix, and exe:plustan gets `if impl(ghc < 9.4) buildable: False` so an old-GHC build fails cleanly instead of dumping GHC API type errors. The now-dead `exclude:` entries (all pre-9.4, plus a 9.4.1 that was never in the matrix) are gone.

2. bytestring >= 0.11, not >= 0.10.

   Stan.Analysis.Analyser uses Data.ByteString.Char8.(!?), which arrived in bytestring-0.11, so the declared bound was already wrong -- this is what the pre-9.4 legs actually died on ("Not in scope: BS8.!?"). The 9.4.7 floor ships 0.11.5.2, so the bound now matches the code.

3. Stop libsodium's autogen.sh clobbering config.sub from the network.

   It ends by curl-ing config.guess/config.sub from git.savannah.gnu.org over the copies its repo already ships. `curl -sL` is silent and ignores HTTP status, so with savannah returning 502 the error page landed in build-aux/config.sub and configure died with "cannot run /bin/bash ./build-aux/config.sub" -- reproduced directly, the download yields a 1114-byte "502 Bad Gateway" HTML page. Setting DO_NOT_UPDATE_CONFIG_SCRIPTS=1 keeps the pinned, committed scripts. The `-s` flag on the call was always a no-op (autogen.sh takes no arguments).

4. Sync .stan-windows.toml with .stan.toml.

   bd8fd16 added `[[remove]]` entries for src/, app/ and test/ to .stan.toml but not to its Windows counterpart, so every windows-latest leg dogfooded stan over stan's own source, found 1238 observations and exited 1. Both files now carry a keep-in-sync note.

Verified locally: lib:stan builds on 9.8.4; `cabal build all --dry-run` under GHC 8.10.7 resolves to lib + exe:stan with exe:plustan correctly dropped; GHC 9.4.7 ships bytestring-0.11.5.2. The libsodium and Windows-dogfooding fixes can only be confirmed by CI.