### PR TITLE
Prep/immutable credential standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ So far, Plu-Stan implements the following automated detection rules:
 | PLU-STAN-11 | Usage of `currencySymbolValueOf` | Warning     | Does not enforce that all token amounts are strictly positive or negative; allows mixed mint/burn in the same transaction |
 | PLU-STAN-12 | Validity interval / POSIX time misuse | Warning     | Using validity interval utilities or accessing `txInfoValidRange` without ensuring finite bounds can lead to unbounded time windows |
 | PLU-STAN-16 | Precision loss: division before multiplication | Warning     | Division before multiplication in integer arithmetic causes precision loss; multiply first, then divide |
+| PLU-STAN-21 | Immutable credentials baked into validators | Warning     | Validator-reachable top-level `PubKeyHash` / `Credential` / `StakingCredential` / `Address` / `ScriptHash` bindings, and credential-like values specialized into validator code via `applyCode` / `unsafeApplyCode`, cannot be rotated on-chain; prefer datum/state-managed credentials |
 
 For comprehensive guidelines on Plinth security patterns, anti-patterns, and best practices, see the [**Rules Documentation**](./rules.md). This includes detailed explanations of the above rules plus additional security considerations not yet automated.
 

--- a/RULES.md
+++ b/RULES.md
@@ -255,7 +255,8 @@ isMaybeStakingCredential' b =
 ## Bindings
 
 - **Non-strict `let` bindings used multiple times:** Make them strict to avoid repeated evaluation. (**Stan:** implemented via `PLU-STAN-08`)
-- **Hardcoded values:** Most ledger-dependent values change across hardforks. Avoid hardcoding unless truly constant; prefer dynamic retrieval or explicit acknowledgment that the value is invariant. 
+- **Immutable credentials baked into validator code:** Validator-reachable top-level `PubKeyHash` / `Credential` / `StakingCredential` / `Address` / `ScriptHash` bindings, or credential-like values specialized into validators with `applyCode` / `unsafeApplyCode`, cannot be rotated on-chain. Prefer storing mutable credentials in datum/state and document intentional immutability. (**Stan:** implemented via `PLU-STAN-21`)
+- **Hardcoded values:** Most ledger-dependent values change across hardforks. Avoid hardcoding unless truly constant; prefer dynamic retrieval or explicit acknowledgment that the value is invariant.
 
 ## Guards
 

--- a/src/Stan/Analysis/Analyser.hs
+++ b/src/Stan/Analysis/Analyser.hs
@@ -1713,22 +1713,22 @@ analyseImmutableCredential insId hie curNode =
 
     bindingIsCredentialLike :: Name -> Bool
     bindingIsCredentialLike name =
-        fromMaybe False
-            (any typeIndexMatchesCredentialLike . Set.toList <$> Map.lookup name bindingTypeIndices)
-            || fromMaybe False (nodeTypeMatchesCredentialLike <$> Map.lookup name bindingNodes)
+        maybe False (any typeIndexMatchesCredentialLike . Set.toList)
+            (Map.lookup name bindingTypeIndices)
+            || maybe False nodeTypeMatchesCredentialLike (Map.lookup name bindingNodes)
 
     bindingProducesCompiledCode :: Name -> Bool
     bindingProducesCompiledCode name =
-        fromMaybe False
-            (any typeIndexReturnsCompiledCode . Set.toList <$> Map.lookup name bindingTypeIndices)
-            || fromMaybe False (nodeReturnsCompiledCode <$> Map.lookup name bindingNodes)
+        maybe False (any typeIndexReturnsCompiledCode . Set.toList)
+            (Map.lookup name bindingTypeIndices)
+            || maybe False nodeReturnsCompiledCode (Map.lookup name bindingNodes)
             || bindingSignatureContainsCompiledCode name
 
     bindingCarriesCompiledCredentialLike :: Name -> Bool
     bindingCarriesCompiledCredentialLike name =
-        fromMaybe False
-            (any typeIndexContainsCompiledCredentialLike . Set.toList <$> Map.lookup name bindingTypeIndices)
-            || fromMaybe False (nodeCarriesCompiledCredentialLike <$> Map.lookup name bindingNodes)
+        maybe False (any typeIndexContainsCompiledCredentialLike . Set.toList)
+            (Map.lookup name bindingTypeIndices)
+            || maybe False nodeCarriesCompiledCredentialLike (Map.lookup name bindingNodes)
             || bindingSignatureContainsCompiledCredentialLike name
 
     nodeReturnsCompiledCode :: HieAST TypeIndex -> Bool
@@ -1820,7 +1820,7 @@ analyseImmutableCredential insId hie curNode =
         insertBindingType acc (ident, IdentifierDetails{identInfo = identInfo', identType = Just ty}) =
             case ident of
                 Right name | any isTrackedBindingCtx identInfo' ->
-                    Map.insertWith (<>) name (Set.singleton ty) acc
+                    Map.insertWith (<>) name (one ty) acc
                 _ -> acc
         insertBindingType acc _ = acc
 
@@ -1934,9 +1934,7 @@ analyseImmutableCredential insId hie curNode =
                         afterCh = bs BS8.!? (idx + BS8.length needle)
                         beforeOk = maybe True (not . isIdentifierChar) beforeCh
                         afterOk = maybe True (not . isIdentifierChar) afterCh
-                    in if beforeOk && afterOk
-                        then True
-                        else go (BS8.drop 1 after)
+                    in (beforeOk && afterOk) || go (BS8.drop 1 after)
     usedBoundNamesInNode :: HieAST TypeIndex -> Set Name
     usedBoundNamesInNode node =
         Set.intersection trackedBindingNames (usedNamesInSubtree node)
@@ -1969,8 +1967,8 @@ analyseImmutableCredential insId hie curNode =
 
     isTrackedBindingCtx :: ContextInfo -> Bool
     isTrackedBindingCtx = \case
-        ValBind _ _ _ -> True
-        PatternBind _ _ _ -> True
+        ValBind {} -> True
+        PatternBind {} -> True
         MatchBind -> True
         _ -> False
 

--- a/src/Stan/Analysis/Analyser.hs
+++ b/src/Stan/Analysis/Analyser.hs
@@ -21,9 +21,9 @@ import Stan.Core.Id (Id)
 import Stan.Core.List (nonRepeatingPairs)
 import Stan.Core.ModuleName (ModuleName (..))
 import Stan.FileInfo (isExtensionDisabled)
-import Stan.Ghc.Compat (Name, RealSrcSpan, isSymOcc, nameOccName, occNameString, srcSpanEndCol,
-                        srcSpanEndLine, srcSpanStartCol, srcSpanStartLine, isExternalName,
-                        IfaceTyCon (..))
+import Stan.Ghc.Compat (Name, RealSrcSpan, isSymOcc, nameModule, nameOccName, occNameString,
+                        srcSpanEndCol, srcSpanEndLine, srcSpanStartCol, srcSpanStartLine,
+                        isExternalName, IfaceTyCon (..))
 import Stan.Hie (eqAst, slice)
 import Stan.Hie.Compat (ContextInfo (..), HieAST (..), HieASTs (..), HieFile (..),
                         HieArgs (..), HieType (..), HieTypeFlat, Identifier, IdentifierDetails (..),
@@ -32,8 +32,8 @@ import Stan.Hie.Compat (ContextInfo (..), HieAST (..), HieASTs (..), HieFile (..
 import Stan.Hie.MatchAst (hieMatchPatternAst)
 import Stan.Hie.MatchType (hieMatchPatternType)
 import Stan.Inspection (Inspection (..), InspectionAnalysis (..))
-import Stan.NameMeta (NameMeta (..), baseNameFrom, ghcPrimNameFrom, hieMatchNameMeta,
-                      plutusTxNameFrom)
+import Stan.NameMeta (NameMeta (..), baseNameFrom, compareNames, ghcPrimNameFrom,
+                      hieMatchNameMeta, plutusTxNameFrom)
 import Stan.Observation (Observations, mkObservation)
 import Stan.Pattern.Ast (Literal (..), PatternAst (..), anyNamesToPatternAst, app, case',
                          constructor, constructorNameIdentifier, dataDecl, fixity, fun,
@@ -1511,6 +1511,589 @@ analysePrecisionLossDivisionBeforeMultiply insId hie curNode =
 
     isIdentChar :: Char -> Bool
     isIdentChar c = isAlphaNum c || c == '_' || c == '\''
+
+analyseImmutableCredential
+    :: Id Inspection
+    -> HieFile
+    -> HieAST TypeIndex
+    -> State VisitorState ()
+analyseImmutableCredential insId hie curNode =
+    addObservations $ mkObservation insId hie <$> matchNode curNode
+  where
+    allHieAsts :: [HieAST TypeIndex]
+    allHieAsts = Map.elems $ getAsts $ hie_asts hie
+
+    bindingSpans :: Map Name RealSrcSpan
+    bindingSpans = foldMap collectBindingSpans allHieAsts
+
+    bindingNodes :: Map Name (HieAST TypeIndex)
+    bindingNodes =
+        let spanIndex = foldMap collectSpanIndex allHieAsts
+        in Map.mapMaybe (`Map.lookup` spanIndex) bindingSpans
+
+    bindingTypeIndices :: Map Name (Set TypeIndex)
+    bindingTypeIndices = foldMap collectBindingTypeIndices allHieAsts
+
+    matchBoundNames :: Set Name
+    matchBoundNames = foldMap collectMatchBoundNames allHieAsts
+
+    sourceLines :: [(Int, ByteString)]
+    sourceLines = zip [1 ..] (BS8.lines $ hie_hs_src hie)
+
+    matchBoundLiftArgumentHelpers :: Set Name
+    matchBoundLiftArgumentHelpers =
+        Set.fromList
+            [ name
+            | name <- Set.toList matchBoundNames
+            , helperDefinitionUsesLiftCode name
+            ]
+
+    credentialLikeBindings :: Set Name
+    credentialLikeBindings =
+        Set.fromList
+            [ name
+            | name <- Set.toList trackedBindingNames
+            , bindingIsCredentialLike name
+            ]
+      where
+        trackedBindingNames =
+            Set.fromList (Map.keys bindingNodes) <> Set.fromList (Map.keys bindingTypeIndices)
+
+    bindingDeps :: Map Name (Set Name)
+    bindingDeps =
+        Map.mapWithKey (\name rhsNode -> Set.delete name $ usedBoundNamesInNode rhsNode) bindingNodes
+
+    liftedCredentialBindings :: Set Name
+    liftedCredentialBindings =
+        expandBindingsByUses (directLiftedCredentialBindings <> sourceLiftedCredentialBindings <> helperAppliedCredentialBindings)
+      where
+        directLiftedCredentialBindings =
+            Set.fromList
+                [ name
+                | (name, rhsNode) <- Map.toList bindingNodes
+                , Just liftedArg <- [liftedCredentialArgument name rhsNode]
+                , liftedArgBakesCredential liftedArg
+                ]
+
+        sourceLiftedCredentialBindings =
+            Set.fromList
+                [ name
+                | (name, deps) <- Map.toList bindingDeps
+                , bindingSourceContainsLiftCode name
+                , not (Set.null $ Set.intersection deps credentialLikeBindings)
+                ]
+
+        liftedCredentialArgument :: Name -> HieAST TypeIndex -> Maybe (HieAST TypeIndex)
+        liftedCredentialArgument name rhsNode
+            | Set.member name matchBoundLiftArgumentHelpers = liftCodeArgument rhsNode
+            | otherwise = directLiftCodeArgument rhsNode
+
+        helperAppliedCredentialBindings =
+            Set.fromList
+                [ name
+                | (name, deps) <- Map.toList bindingDeps
+                , bindingSourceUsesAnyBinding matchBoundLiftArgumentHelpers name
+                    || not (Set.null $ Set.intersection deps matchBoundLiftArgumentHelpers)
+                , bindingSourceUsesAnyBinding credentialLikeBindings name
+                    || not (Set.null $ Set.intersection deps credentialLikeBindings)
+                ]
+
+    credentialCarrierBindings :: Set Name
+    credentialCarrierBindings =
+        expandCredentialCarriers liftedCredentialBindings
+
+    projectedCredentialBindings :: Set Name
+    projectedCredentialBindings =
+        liftedCredentialBindings <> Set.filter bindingCarriesCompiledCredentialLike credentialCarrierBindings
+
+    appliedCredentialSites :: [(RealSrcSpan, Set Name)]
+    appliedCredentialSites =
+        concatMap collectAppliedCredentialSites allHieAsts
+
+    appliedCredentialSpans :: Set RealSrcSpan
+    appliedCredentialSpans = Set.fromList $ map fst appliedCredentialSites
+
+    validatorReachableCredentialBindings :: Set Name
+    validatorReachableCredentialBindings =
+        foldMap (reachableCredentialBindingsFromNames . snd) appliedCredentialSites
+
+    topLevelReachableCredentialSpans :: Set RealSrcSpan
+    topLevelReachableCredentialSpans =
+        Set.fromList
+            [ span'
+            | (name, span') <- Map.toList bindingSpans
+            , isTopLevelBindingSpan span'
+            , Set.member name credentialLikeBindings
+            , Set.member name validatorReachableCredentialBindings
+            ]
+
+    matchNode :: HieAST TypeIndex -> Slist RealSrcSpan
+    matchNode node
+        | nodeSpan node `Set.member` topLevelReachableCredentialSpans
+            || nodeSpan node `Set.member` appliedCredentialSpans =
+            S.one $ nodeSpan node
+        | otherwise = mempty
+
+    collectAppliedCredentialSites :: HieAST TypeIndex -> [(RealSrcSpan, Set Name)]
+    collectAppliedCredentialSites node =
+        let here = case applyCodeOperands node of
+                Just (_compiledNode, argNode)
+                    | Just liftedArg <- liftCodeArgument argNode
+                    , liftedArgBakesCredential liftedArg ->
+                        [(nodeSpan liftedArg, usedBoundNamesInNode liftedArg)]
+                    | nodeUsesLiftedCredentialBinding argNode ->
+                        [(nodeSpan argNode, usedBoundNamesInNode argNode)]
+                _ -> []
+        in here <> concatMap collectAppliedCredentialSites (nodeChildren node)
+
+    liftedArgBakesCredential :: HieAST TypeIndex -> Bool
+    liftedArgBakesCredential liftedArg =
+        nodeTypeMatchesCredentialLike liftedArg
+            || not (Set.null $ reachableCredentialBindingsFromNames $ usedBoundNamesInNode liftedArg)
+
+    nodeUsesLiftedCredentialBinding :: HieAST TypeIndex -> Bool
+    nodeUsesLiftedCredentialBinding node =
+        not $ Set.null $ Set.intersection projectedCredentialBindings (usedBoundNamesInNode node)
+
+    reachableCredentialBindingsFromNames :: Set Name -> Set Name
+    reachableCredentialBindingsFromNames names =
+        Set.intersection credentialLikeBindings (reachableBindingClosure names)
+
+    reachableBindingClosure :: Set Name -> Set Name
+    reachableBindingClosure initial =
+        go $ Set.intersection trackedBindingNames initial
+      where
+        trackedBindingNames = Set.fromList $ Map.keys bindingNodes
+
+        go seen =
+            let newDeps =
+                    Set.fromList
+                        [ dep
+                        | name <- Set.toList seen
+                        , dep <- Set.toList $ Map.findWithDefault Set.empty name bindingDeps
+                        , not (Set.member dep seen)
+                        ]
+            in if Set.null newDeps
+               then seen
+               else go (seen <> newDeps)
+
+    expandBindingsByUses :: Set Name -> Set Name
+    expandBindingsByUses = go
+      where
+        go tainted =
+            let newTainted =
+                    Set.fromList
+                        [ name
+                        | (name, deps) <- Map.toList bindingDeps
+                        , bindingProducesCompiledCode name
+                        , not (Set.member name tainted)
+                        , not (Set.null $ Set.intersection deps tainted)
+                        ]
+            in if Set.null newTainted
+               then tainted
+               else go (tainted <> newTainted)
+
+    expandCredentialCarriers :: Set Name -> Set Name
+    expandCredentialCarriers = go
+      where
+        go carriers =
+            let newCarriers =
+                    Set.fromList
+                        [ name
+                        | (name, deps) <- Map.toList bindingDeps
+                        , bindingCarriesCompiledCredentialLike name
+                        , not (Set.member name carriers)
+                        , not (Set.null $ Set.intersection deps carriers)
+                        ]
+            in if Set.null newCarriers
+               then carriers
+               else go (carriers <> newCarriers)
+
+    bindingIsCredentialLike :: Name -> Bool
+    bindingIsCredentialLike name =
+        fromMaybe False
+            (any typeIndexMatchesCredentialLike . Set.toList <$> Map.lookup name bindingTypeIndices)
+            || fromMaybe False (nodeTypeMatchesCredentialLike <$> Map.lookup name bindingNodes)
+
+    bindingProducesCompiledCode :: Name -> Bool
+    bindingProducesCompiledCode name =
+        fromMaybe False
+            (any typeIndexReturnsCompiledCode . Set.toList <$> Map.lookup name bindingTypeIndices)
+            || fromMaybe False (nodeReturnsCompiledCode <$> Map.lookup name bindingNodes)
+            || bindingSignatureContainsCompiledCode name
+
+    bindingCarriesCompiledCredentialLike :: Name -> Bool
+    bindingCarriesCompiledCredentialLike name =
+        fromMaybe False
+            (any typeIndexContainsCompiledCredentialLike . Set.toList <$> Map.lookup name bindingTypeIndices)
+            || fromMaybe False (nodeCarriesCompiledCredentialLike <$> Map.lookup name bindingNodes)
+            || bindingSignatureContainsCompiledCredentialLike name
+
+    nodeReturnsCompiledCode :: HieAST TypeIndex -> Bool
+    nodeReturnsCompiledCode node = any typeIndexReturnsCompiledCode (nodeTypeIndices node)
+
+    typeIndexReturnsCompiledCode :: TypeIndex -> Bool
+    typeIndexReturnsCompiledCode ix =
+        hieTypeReturnsTyConName "CompiledCode" (hie_types hie Arr.! ix)
+
+    hieTypeReturnsTyConName :: String -> HieTypeFlat -> Bool
+    hieTypeReturnsTyConName needle = \case
+        HTyConApp IfaceTyCon{ifaceTyConName = tyConName} _ ->
+            occNameString (nameOccName tyConName) == needle
+        HFunTy _ _ resultIx ->
+            hieTypeReturnsTyConName needle (hie_types hie Arr.! resultIx)
+        HForAllTy _ innerIx ->
+            hieTypeReturnsTyConName needle (hie_types hie Arr.! innerIx)
+        HQualTy _ innerIx ->
+            hieTypeReturnsTyConName needle (hie_types hie Arr.! innerIx)
+        _ -> False
+
+    nodeCarriesCompiledCredentialLike :: HieAST TypeIndex -> Bool
+    nodeCarriesCompiledCredentialLike node =
+        let typeIndices = nodeTypeIndices node
+        in if null typeIndices
+            then any nodeCarriesCompiledCredentialLike (nodeChildren node)
+            else any typeIndexContainsCompiledCredentialLike typeIndices
+
+    typeIndexContainsCompiledCredentialLike :: TypeIndex -> Bool
+    typeIndexContainsCompiledCredentialLike ix =
+        hieTypeContainsCompiledCredentialLike (hie_types hie Arr.! ix)
+
+    hieTypeContainsCompiledCredentialLike :: HieTypeFlat -> Bool
+    hieTypeContainsCompiledCredentialLike = \case
+        HTyConApp IfaceTyCon{ifaceTyConName = tyConName} (HieArgs args) ->
+            let here =
+                    occNameString (nameOccName tyConName) == "CompiledCode"
+                        && any (typeIndexMatchesCredentialLike . snd) args
+            in here || any (hieTypeContainsCompiledCredentialLike . (hie_types hie Arr.!) . snd) args
+        HFunTy _ a b ->
+            hieTypeContainsCompiledCredentialLike (hie_types hie Arr.! a)
+                || hieTypeContainsCompiledCredentialLike (hie_types hie Arr.! b)
+        HForAllTy _ innerIx ->
+            hieTypeContainsCompiledCredentialLike (hie_types hie Arr.! innerIx)
+        HQualTy _ innerIx ->
+            hieTypeContainsCompiledCredentialLike (hie_types hie Arr.! innerIx)
+        _ -> False
+
+    isTopLevelBindingSpan :: RealSrcSpan -> Bool
+    isTopLevelBindingSpan span' = srcSpanStartCol span' == 1
+
+
+    collectSpanIndex :: HieAST TypeIndex -> Map RealSrcSpan (HieAST TypeIndex)
+    collectSpanIndex n@Node{nodeSpan = span', nodeChildren = children} =
+        Map.insertWith (\_new old -> old) span' n (foldMap collectSpanIndex children)
+
+    collectBindingSpans :: HieAST TypeIndex -> Map Name RealSrcSpan
+    collectBindingSpans = go mempty
+      where
+        go acc n@Node{nodeSpan = fallbackSpan, nodeChildren = children} =
+            let info = nodeInfo n
+                acc' = foldl' (insertBinding fallbackSpan) acc (Map.assocs $ nodeIdentifiers info)
+            in foldl' go acc' children
+
+        insertBinding
+            :: RealSrcSpan
+            -> Map Name RealSrcSpan
+            -> (Identifier, IdentifierDetails TypeIndex)
+            -> Map Name RealSrcSpan
+        insertBinding fallbackSpan acc (ident, details) = case ident of
+            Right name | Just bindSpan <- getBindingSpan details ->
+                Map.insertWith (\_new old -> old) name bindSpan acc
+            Right name | isTrackedBindingDetails details ->
+                Map.insertWith (\_new old -> old) name fallbackSpan acc
+            _ -> acc
+
+    collectBindingTypeIndices :: HieAST TypeIndex -> Map Name (Set TypeIndex)
+    collectBindingTypeIndices = go mempty
+      where
+        go acc n@Node{nodeChildren = children} =
+            let info = nodeInfo n
+                acc' = foldl' insertBindingType acc (Map.assocs $ nodeIdentifiers info)
+            in foldl' go acc' children
+
+        insertBindingType
+            :: Map Name (Set TypeIndex)
+            -> (Identifier, IdentifierDetails TypeIndex)
+            -> Map Name (Set TypeIndex)
+        insertBindingType acc (ident, IdentifierDetails{identInfo = identInfo', identType = Just ty}) =
+            case ident of
+                Right name | any isTrackedBindingCtx identInfo' ->
+                    Map.insertWith (<>) name (Set.singleton ty) acc
+                _ -> acc
+        insertBindingType acc _ = acc
+
+
+
+    collectMatchBoundNames :: HieAST TypeIndex -> Set Name
+    collectMatchBoundNames = go
+      where
+        go n@Node{nodeChildren = children} =
+            matchBoundsHere n <> foldMap go children
+
+        matchBoundsHere :: HieAST TypeIndex -> Set Name
+        matchBoundsHere node =
+            Set.fromList
+                [ name
+                | (Right name, IdentifierDetails{identInfo = identInfo'}) <- Map.assocs $ nodeIdentifiers $ nodeInfo node
+                , MatchBind `Set.member` identInfo'
+                ]
+
+    bindingSourceContainsLiftCode :: Name -> Bool
+    bindingSourceContainsLiftCode name = fromMaybe False $ do
+        block <- bindingSourceBlock name
+        pure $ any (`BS8.isInfixOf` block) ["liftCodeDef", "liftCode"]
+
+    bindingSourceUsesAnyBinding :: Set Name -> Name -> Bool
+    bindingSourceUsesAnyBinding names targetName =
+        let bindingOccs =
+                [ BS8.pack (occNameString $ nameOccName name)
+                | name <- Set.toList names
+                ]
+        in fromMaybe False $ do
+            block <- bindingSourceBlock targetName
+            pure $ any (`containsWordBS` block) bindingOccs
+
+    bindingSignatureContainsCompiledCode :: Name -> Bool
+    bindingSignatureContainsCompiledCode name = fromMaybe False $ do
+        sig <- bindingSignatureLine name
+        pure $ containsWordBS "CompiledCode" sig
+
+    bindingSignatureContainsCompiledCredentialLike :: Name -> Bool
+    bindingSignatureContainsCompiledCredentialLike name = fromMaybe False $ do
+        sig <- bindingSignatureLine name
+        pure $
+            containsWordBS "CompiledCode" sig
+                && any (`containsWordBS` sig)
+                    [ "PubKeyHash"
+                    , "ScriptHash"
+                    , "Credential"
+                    , "StakingCredential"
+                    , "Address"
+                    ]
+
+    bindingSignatureLine :: Name -> Maybe ByteString
+    bindingSignatureLine name = do
+        span' <- Map.lookup name bindingSpans
+        prevLine <- previousSignificantLine (srcSpanStartLine span' - 1)
+        let binderOcc = BS8.pack (occNameString $ nameOccName name)
+            trimmed = BS8.dropWhile isSpace $ lineCodePart prevLine
+        guard $ (binderOcc <> " ::") `BS8.isPrefixOf` trimmed || (binderOcc <> "::") `BS8.isPrefixOf` trimmed
+        pure trimmed
+
+    previousSignificantLine :: Int -> Maybe ByteString
+    previousSignificantLine lineNumber
+        | lineNumber < 1 = Nothing
+        | otherwise = do
+            rawLine <- snd <$> find ((== lineNumber) . fst) sourceLines
+            let trimmed = BS8.dropWhile isSpace $ lineCodePart rawLine
+            if BS8.null trimmed
+                then previousSignificantLine (lineNumber - 1)
+                else Just rawLine
+
+    bindingSourceBlock :: Name -> Maybe ByteString
+    bindingSourceBlock name = do
+        span' <- Map.lookup name bindingSpans
+        let bindingIndent = srcSpanStartCol span' - 1
+            blockLines = map snd $ takeWhile (belongsToBindingBlock (srcSpanStartLine span') bindingIndent)
+                $ drop (srcSpanStartLine span' - 1) sourceLines
+        pure $ BS8.unlines $ map lineCodePart blockLines
+
+    helperDefinitionUsesLiftCode :: Name -> Bool
+    helperDefinitionUsesLiftCode = bindingSourceContainsLiftCode
+
+    belongsToBindingBlock :: Int -> Int -> (Int, ByteString) -> Bool
+    belongsToBindingBlock startLine bindingIndent (lineNumber, rawLine)
+        | lineNumber == startLine = True
+        | otherwise =
+            let code = lineCodePart rawLine
+                stripped = BS8.dropWhile isSpace code
+            in BS8.null stripped || sourceLineIndent rawLine > bindingIndent
+
+    sourceLineIndent :: ByteString -> Int
+    sourceLineIndent = BS8.length . BS8.takeWhile isSpace
+
+    lineCodePart :: ByteString -> ByteString
+    lineCodePart = fst . BS8.breakSubstring "--"
+
+    isIdentifierChar :: Char -> Bool
+    isIdentifierChar c = isAlphaNum c || c == '_' || c == '\''
+
+    containsWordBS :: ByteString -> ByteString -> Bool
+    containsWordBS needle haystack
+        | BS8.null needle = False
+        | otherwise = go haystack
+      where
+        go bs = case BS8.breakSubstring needle bs of
+            (_before, after)
+                | BS8.null after -> False
+                | otherwise ->
+                    let idx = BS8.length bs - BS8.length after
+                        beforeCh = bs BS8.!? (idx - 1)
+                        afterCh = bs BS8.!? (idx + BS8.length needle)
+                        beforeOk = maybe True (not . isIdentifierChar) beforeCh
+                        afterOk = maybe True (not . isIdentifierChar) afterCh
+                    in if beforeOk && afterOk
+                        then True
+                        else go (BS8.drop 1 after)
+    usedBoundNamesInNode :: HieAST TypeIndex -> Set Name
+    usedBoundNamesInNode node =
+        Set.intersection trackedBindingNames (usedNamesInSubtree node)
+      where
+        trackedBindingNames = Set.fromList $ Map.keys bindingNodes
+
+    usedNamesInSubtree :: HieAST TypeIndex -> Set Name
+    usedNamesInSubtree n@Node{nodeChildren = children} =
+        usedNamesHere n <> foldMap usedNamesInSubtree children
+
+    usedNamesHere :: HieAST TypeIndex -> Set Name
+    usedNamesHere node =
+        Set.fromList
+            [ identName
+            | (Right identName, IdentifierDetails{identInfo = identInfo'}) <- Map.assocs $ nodeIdentifiers $ nodeInfo node
+            , Set.member Use identInfo'
+            ]
+
+    getBindingSpan :: IdentifierDetails TypeIndex -> Maybe RealSrcSpan
+    getBindingSpan IdentifierDetails{identInfo = identInfo'} =
+        listToMaybe $ mapMaybe spanFromCtx (toList identInfo')
+      where
+        spanFromCtx (ValBind _ _ (Just s)) = Just s
+        spanFromCtx (PatternBind _ _ (Just s)) = Just s
+        spanFromCtx _ = Nothing
+
+    isTrackedBindingDetails :: IdentifierDetails TypeIndex -> Bool
+    isTrackedBindingDetails IdentifierDetails{identInfo = identInfo'} =
+        any isTrackedBindingCtx identInfo'
+
+    isTrackedBindingCtx :: ContextInfo -> Bool
+    isTrackedBindingCtx = \case
+        ValBind _ _ _ -> True
+        PatternBind _ _ _ -> True
+        MatchBind -> True
+        _ -> False
+
+    applyCodeOperands :: HieAST TypeIndex -> Maybe (HieAST TypeIndex, HieAST TypeIndex)
+    applyCodeOperands node =
+        infixApplyCodeOperands node <|> prefixApplyCodeOperands node
+
+    infixApplyCodeOperands :: HieAST TypeIndex -> Maybe (HieAST TypeIndex, HieAST TypeIndex)
+    infixApplyCodeOperands node = do
+        guard $ nodeHasAnnotation opAppAnnotation node
+        compiledNode:opNode:argNode:_ <- Just $ nodeChildren node
+        guard $ nodeHasAnyPlutusTxOcc ["applyCode", "unsafeApplyCode"] opNode
+        pure (compiledNode, argNode)
+
+    prefixApplyCodeOperands :: HieAST TypeIndex -> Maybe (HieAST TypeIndex, HieAST TypeIndex)
+    prefixApplyCodeOperands node = do
+        guard $ nodeHasAnnotation hsAppAnnotation node
+        let (headNode, args) = appSpine node
+        guard $ nodeHasAnyPlutusTxOcc ["applyCode", "unsafeApplyCode"] headNode
+        compiledNode:argNode:_ <- Just args
+        pure (compiledNode, argNode)
+
+    directLiftCodeArgument :: HieAST TypeIndex -> Maybe (HieAST TypeIndex)
+    directLiftCodeArgument node = do
+        let (headNode, args) = appSpine node
+        guard $ nodeHasAnyPlutusTxOcc ["liftCode", "liftCodeDef"] headNode
+        lastMaybe args
+
+    liftCodeArgument :: HieAST TypeIndex -> Maybe (HieAST TypeIndex)
+    liftCodeArgument node =
+        directLiftCodeArgument node <|> foldr ((<|>) . liftCodeArgument) Nothing (nodeChildren node)
+
+    nodeHasAnyPlutusTxOcc :: [Text] -> HieAST TypeIndex -> Bool
+    nodeHasAnyPlutusTxOcc occNames = go
+      where
+        go n@Node{nodeChildren = children} =
+            any (identifierMatchesAnyPlutusTxOcc occNames) (Map.assocs $ nodeIdentifiers $ nodeInfo n)
+                || any go children
+
+    identifierMatchesAnyPlutusTxOcc
+        :: [Text]
+        -> (Identifier, IdentifierDetails TypeIndex)
+        -> Bool
+    identifierMatchesAnyPlutusTxOcc occNames (Right name, _details) =
+        any (\occName -> nameMatchesExternal "plutus-tx" "PlutusTx" occName name) occNames
+    identifierMatchesAnyPlutusTxOcc _ _ = False
+
+    nodeTypeMatchesCredentialLike :: HieAST TypeIndex -> Bool
+    nodeTypeMatchesCredentialLike node =
+        let typeIndices = nodeTypeIndices node
+        in if null typeIndices
+            then any nodeTypeMatchesCredentialLike (nodeChildren node)
+            else any typeIndexMatchesCredentialLike typeIndices
+
+    typeIndexMatchesCredentialLike :: TypeIndex -> Bool
+    typeIndexMatchesCredentialLike ix =
+        hieTypeMatchesCredentialLike (hie_types hie Arr.! ix)
+
+    hieTypeMatchesCredentialLike :: HieTypeFlat -> Bool
+    hieTypeMatchesCredentialLike = \case
+        HTyConApp IfaceTyCon{ifaceTyConName = tyConName} _ ->
+            isCredentialLikeTyCon tyConName
+        HForAllTy _ innerIx ->
+            typeIndexMatchesCredentialLike innerIx
+        HQualTy _ innerIx ->
+            typeIndexMatchesCredentialLike innerIx
+        _ -> False
+
+    isCredentialLikeTyCon :: Name -> Bool
+    isCredentialLikeTyCon tyConName =
+        any (\occName -> nameMatchesExternal "plutus-ledger-api" "PlutusLedgerApi" occName tyConName)
+            [ "PubKeyHash"
+            , "ScriptHash"
+            , "Credential"
+            , "StakingCredential"
+            , "Address"
+            ]
+
+    nameMatchesExternal :: Text -> Text -> Text -> Name -> Bool
+    nameMatchesExternal packageName modulePrefix occName name
+        | not (isExternalName name) = False
+        | otherwise =
+            let moduleName = fromGhcModule $ nameModule name
+            in modulePrefix `T.isPrefixOf` unModuleName moduleName
+                && compareNames
+                    NameMeta
+                        { nameMetaPackage = packageName
+                        , nameMetaModuleName = moduleName
+                        , nameMetaName = occName
+                        }
+                    name
+
+    nodeTypeIndices :: HieAST TypeIndex -> [TypeIndex]
+    nodeTypeIndices node =
+        let NodeInfo{nodeType = nodeTypes, nodeIdentifiers = identifiers} = nodeInfo node
+            identTypes =
+                [ ty
+                | (_ident, IdentifierDetails{identType = Just ty}) <- Map.assocs identifiers
+                ]
+        in nodeTypes <> identTypes
+
+    nodeHasAnnotation :: NodeAnnotation -> HieAST TypeIndex -> Bool
+    nodeHasAnnotation ann node =
+        let NodeInfo{nodeAnnotations = nodeAnnotations'} = nodeInfo node
+        in ann `Set.member` Set.map toNodeAnnotation nodeAnnotations'
+
+    appSpine :: HieAST TypeIndex -> (HieAST TypeIndex, [HieAST TypeIndex])
+    appSpine node = case node of
+        n@Node{nodeChildren = appFun:arg:_}
+            | nodeHasAnnotation hsAppAnnotation n ->
+                let (f, args) = appSpine appFun
+                in (f, args <> [arg])
+        _ -> (node, [])
+
+    lastMaybe :: [a] -> Maybe a
+    lastMaybe = \case
+        [] -> Nothing
+        [x] -> Just x
+        _ : xs -> lastMaybe xs
+
+    hsAppAnnotation :: NodeAnnotation
+    hsAppAnnotation = mkNodeAnnotation "HsApp" "HsExpr"
+
+    opAppAnnotation :: NodeAnnotation
+    opAppAnnotation = mkNodeAnnotation "OpApp" "HsExpr"
 
 analyseUnsafeFromBuiltinDataInHashComparison
     :: Id Inspection

--- a/src/Stan/Analysis/Analyser.hs
+++ b/src/Stan/Analysis/Analyser.hs
@@ -14,12 +14,13 @@ module Stan.Analysis.Analyser
 import Extensions (ExtensionsResult)
 import GHC.LanguageExtensions.Type (Extension (Strict, StrictData))
 import Slist (Slist)
+import qualified Data.Text as T
 
 import Stan.Analysis.Visitor (Visitor (..), VisitorState (..), addFixity, addObservation,
                               addObservations, addOpDecl, getFinalObservations)
 import Stan.Core.Id (Id)
 import Stan.Core.List (nonRepeatingPairs)
-import Stan.Core.ModuleName (ModuleName (..))
+import Stan.Core.ModuleName (ModuleName (..), fromGhcModule)
 import Stan.FileInfo (isExtensionDisabled)
 import Stan.Ghc.Compat (Name, RealSrcSpan, isSymOcc, nameModule, nameOccName, occNameString,
                         srcSpanEndCol, srcSpanEndLine, srcSpanStartCol, srcSpanStartLine,
@@ -85,6 +86,7 @@ createVisitor hie exts inspections = Visitor $ \node ->
         PrecisionLossDivisionBeforeMultiply -> analysePrecisionLossDivisionBeforeMultiply inspectionId hie node
         RedeemerSuppliedIndicesUniqueness -> analyseRedeemerSuppliedIndicesUniqueness inspectionId hie node
         LazyAndInOnChainCode -> analyseLazyAndInOnChainCode inspectionId hie node
+        ImmutableCredential -> analyseImmutableCredential inspectionId hie node
         MissingTxOutReferenceScriptCheck -> analyseMissingTxOutReferenceScriptCheck inspectionId hie node
         MissingTxOutStakingCredentialCheck -> analyseMissingTxOutStakingCredentialCheck inspectionId hie node
         MissingTxOutValueCheck -> analyseMissingTxOutValueCheck inspectionId hie node

--- a/src/Stan/Analysis/Analyser.hs
+++ b/src/Stan/Analysis/Analyser.hs
@@ -68,7 +68,12 @@ createVisitor
     -> ExtensionsResult
     -> [Inspection]
     -> Visitor
-createVisitor hie exts inspections = Visitor $ \node ->
+createVisitor hie exts inspections =
+    -- Bound outside the per-node lambda so it is computed at most once per
+    -- file, and lazily: a module with no ImmutableCredential inspection
+    -- enabled never forces it. See 'immutableCredentialSpans'.
+    let credentialSpans = immutableCredentialSpans hie
+    in Visitor $ \node ->
     forM_ inspections $ \Inspection{..} -> case inspectionAnalysis of
         FindAst patAst -> matchAst inspectionId patAst hie node
         Infix -> analyseInfix hie node
@@ -86,7 +91,7 @@ createVisitor hie exts inspections = Visitor $ \node ->
         PrecisionLossDivisionBeforeMultiply -> analysePrecisionLossDivisionBeforeMultiply inspectionId hie node
         RedeemerSuppliedIndicesUniqueness -> analyseRedeemerSuppliedIndicesUniqueness inspectionId hie node
         LazyAndInOnChainCode -> analyseLazyAndInOnChainCode inspectionId hie node
-        ImmutableCredential -> analyseImmutableCredential inspectionId hie node
+        ImmutableCredential -> analyseImmutableCredential credentialSpans inspectionId hie node
         MissingTxOutReferenceScriptCheck -> analyseMissingTxOutReferenceScriptCheck inspectionId hie node
         MissingTxOutStakingCredentialCheck -> analyseMissingTxOutStakingCredentialCheck inspectionId hie node
         MissingTxOutValueCheck -> analyseMissingTxOutValueCheck inspectionId hie node
@@ -1514,13 +1519,26 @@ analysePrecisionLossDivisionBeforeMultiply insId hie curNode =
     isIdentChar :: Char -> Bool
     isIdentChar c = isAlphaNum c || c == '_' || c == '\''
 
-analyseImmutableCredential
-    :: Id Inspection
-    -> HieFile
-    -> HieAST TypeIndex
-    -> State VisitorState ()
-analyseImmutableCredential insId hie curNode =
-    addObservations $ mkObservation insId hie <$> matchNode curNode
+{- | File-level state for PLU-STAN-21: the spans of every credential-like
+binding a validator can reach, plus every site that bakes one into compiled
+code.
+
+Computed once per 'HieFile' rather than per node. It depends only on @hie@ --
+it walks the whole forest and iterates several fixpoints -- while the per-node
+step is just a set-membership test. The visitor calls the analyser for every
+node in the module, so while this lived in the analyser's @where@ block it was
+rebuilt on each visit. 'createVisitor' now binds it once per file, and lazily,
+so a module that never reaches this inspection pays nothing.
+
+On measured cost: the per-node version was not in fact slow at the scales
+tried -- about 100ms across 60 modules / 15k LOC, under 1% of the run. This is
+a structural fix rather than a demonstrated speed-up; it is cheap insurance for
+modules much larger than anything in this repo, not a fix for an observed
+problem.
+-}
+immutableCredentialSpans :: HieFile -> Set RealSrcSpan
+immutableCredentialSpans hie =
+    topLevelReachableCredentialSpans <> appliedCredentialSpans
   where
     allHieAsts :: [HieAST TypeIndex]
     allHieAsts = Map.elems $ getAsts $ hie_asts hie
@@ -1628,13 +1646,6 @@ analyseImmutableCredential insId hie curNode =
             , Set.member name credentialLikeBindings
             , Set.member name validatorReachableCredentialBindings
             ]
-
-    matchNode :: HieAST TypeIndex -> Slist RealSrcSpan
-    matchNode node
-        | nodeSpan node `Set.member` topLevelReachableCredentialSpans
-            || nodeSpan node `Set.member` appliedCredentialSpans =
-            S.one $ nodeSpan node
-        | otherwise = mempty
 
     collectAppliedCredentialSites :: HieAST TypeIndex -> [(RealSrcSpan, Set Name)]
     collectAppliedCredentialSites node =
@@ -2100,6 +2111,22 @@ analyseUnsafeFromBuiltinDataInHashComparison
     -> HieFile
     -> HieAST TypeIndex
     -> State VisitorState ()
+
+-- | PLU-STAN-21: report any node whose span is a known baked-in credential
+-- site. All the work lives in 'immutableCredentialSpans'.
+analyseImmutableCredential
+    :: Set RealSrcSpan
+    -> Id Inspection
+    -> HieFile
+    -> HieAST TypeIndex
+    -> State VisitorState ()
+analyseImmutableCredential credentialSpans insId hie curNode =
+    addObservations $ mkObservation insId hie <$> matchNode curNode
+  where
+    matchNode :: HieAST TypeIndex -> Slist RealSrcSpan
+    matchNode node
+        | nodeSpan node `Set.member` credentialSpans = S.one $ nodeSpan node
+        | otherwise = mempty
 analyseUnsafeFromBuiltinDataInHashComparison insId hie curNode =
     addObservations $ mkObservation insId hie <$> matchNode curNode
   where

--- a/src/Stan/Inspection.hs
+++ b/src/Stan/Inspection.hs
@@ -132,6 +132,8 @@ data InspectionAnalysis
     | RedeemerSuppliedIndicesUniqueness
     -- | `&&` used in on-chain code (prefer strict builtinAnd).
     | LazyAndInOnChainCode
+    -- | Credential-like values are stored top-level or baked into compiled code.
+    | ImmutableCredential
     -- | TxOut validation misses reference script checks.
     | MissingTxOutReferenceScriptCheck
     -- | TxOut validation misses staking credential checks.

--- a/src/Stan/Inspection/AntiPattern.hs
+++ b/src/Stan/Inspection/AntiPattern.hs
@@ -67,6 +67,7 @@ module Stan.Inspection.AntiPattern
     , plustan17
     , plustan18
     , plustan19
+    , plustan21
     -- * All inspections
     , antiPatternInspectionsMap
     ) where
@@ -133,6 +134,7 @@ antiPatternInspectionsMap = fromList $ fmapToFst inspectionId
     , plustan17
     , plustan18
     , plustan19
+    , plustan21
     ]
 
 -- | Smart constructor to create anti-pattern 'Inspection'.
@@ -823,6 +825,18 @@ plustan19 = mkAntiPatternInspection (Id "PLU-STAN-19") "TxOut validation misses 
     & solutionL .~
         [ "Validate datum shape and critical datum fields for security-sensitive outputs"
         , "If datum is intentionally unconstrained, document this and suppress the warning"
+        ]
+    & withPlutusCategory
+    & severityL .~ Warning
+
+plustan21 :: Inspection
+plustan21 = mkAntiPatternInspection (Id "PLU-STAN-21") "Immutable credentials baked into validators"
+    ImmutableCredential
+    & descriptionL .~ "Validator-reachable top-level PubKeyHash/Credential/StakingCredential/Address/ScriptHash bindings, and credential-like values specialized into compiled validator code via applyCode/unsafeApplyCode, cannot be rotated on-chain when governance, signer sets, or recovery requirements change."
+    & solutionL .~
+        [ "Store mutable credentials in datum/state that validators can update under explicit authorization"
+        , "Avoid baking credential-like values into compiled code via applyCode/unsafeApplyCode unless immutability is intentional and documented"
+        , "If the credential is intentionally immutable, suppress the warning locally and document the operational trade-off"
         ]
     & withPlutusCategory
     & severityL .~ Warning

--- a/src/Stan/Plinth/Docs.hs
+++ b/src/Stan/Plinth/Docs.hs
@@ -517,4 +517,33 @@ plinthDocsMap = fromList
           , docsAnchor = ""
           }
       )
+    , ( Id "PLU-STAN-21"
+      , InspectionDocs
+          { docsWhyItMatters = unlines
+              [ "A credential compiled into a validator is a key you can never rotate. A"
+              , "script\'s address derives from its hash, so replacing the constant -- or the"
+              , "value applied to the compiled code via applyCode -- produces a *different*"
+              , "script at a *different* address. If that key is lost every UTxO it guards is"
+              , "frozen; if it is compromised the attacker keeps that authority until you"
+              , "deploy a new script and migrate every locked UTxO to it. Holding the"
+              , "credential in datum instead lets a governance action replace it in one"
+              , "transaction, with no redeploy and no migration."
+              ]
+          , docsBadExample = unlines
+              [ "-- baked in two ways: as a top-level constant, and specialised into the"
+              , "-- compiled validator, so neither can be changed after deployment"
+              , "adminKey :: PubKeyHash"
+              , "adminKey = PubKeyHash \"a1b2c3...\""
+              , ""
+              , "validator = $$(compile [|| mkValidator ||]) `unsafeApplyCode` liftCodeDef adminKey"
+              ]
+          , docsGoodExample = unlines
+              [ "-- the authority lives in the datum and can be rotated in place"
+              , "data VaultDatum = VaultDatum { vaultAdmin :: PubKeyHash }"
+              , ""
+              , "signedByAdmin d info = vaultAdmin d `elem` txInfoSignatories info"
+              ]
+          , docsAnchor = ""
+          }
+      )
     ]

--- a/target/Target/PlutusTx.hs
+++ b/target/Target/PlutusTx.hs
@@ -19,7 +19,7 @@ import PlutusTx.List qualified as TxList
 import PlutusTx.Prelude qualified as P
 
 -- Place for future imports
-import PlutusLedgerApi.V1 (Credential (..), POSIXTime, POSIXTimeRange, PubKeyHash (..), ScriptHash (..))
+import PlutusLedgerApi.V1 (Credential (..), POSIXTime, POSIXTimeRange, PubKeyHash (..), ScriptHash (..), StakingCredential (..))
 import PlutusLedgerApi.V1.Contexts qualified as V1
 import PlutusLedgerApi.V1.Interval qualified as Interval
 import PlutusLedgerApi.V1.Value qualified as Value

--- a/target/Target/PlutusTx.hs
+++ b/target/Target/PlutusTx.hs
@@ -1427,7 +1427,7 @@ plutStan21UnusedAdminKeyShouldPass =
   PubKeyHash (BI.stringToBuiltinByteStringHex "cafebabe")
 
 plutStan21CompiledAdminValidator :: Tx.CompiledCode (PubKeyHash -> BuiltinData -> BuiltinData)
-plutStan21CompiledAdminValidator = undefined
+plutStan21CompiledAdminValidator = undefined  -- stan-ignore: STAN-0212
 
 plutStan21BakedLocalCredentialApplyCode :: Either String (Tx.CompiledCode (BuiltinData -> BuiltinData))
 -- PLU-STAN-21 (should trigger): locally scoped credentials specialized with applyCode are still baked into the validator.
@@ -1437,7 +1437,7 @@ plutStan21BakedLocalCredentialApplyCode =
   in Tx.applyCode plutStan21CompiledAdminValidator (Tx.liftCodeDef localAdminKey)
 
 plutStan21CompiledAddressValidator :: Tx.CompiledCode (Address -> BuiltinData -> BuiltinData)
-plutStan21CompiledAddressValidator = undefined
+plutStan21CompiledAddressValidator = undefined  -- stan-ignore: STAN-0212
 
 plutStan21BakedAddressUnsafeApplyCode :: Tx.CompiledCode (BuiltinData -> BuiltinData)
 -- PLU-STAN-21 (should trigger): credential-like address baked into compiled code via unsafeApplyCode.
@@ -1450,7 +1450,7 @@ plutStan21ImplicitCredential =
   PubKeyCredential plutStan21ImmutableAdminKey
 
 plutStan21CompiledCredentialValidator :: Tx.CompiledCode (Credential -> BuiltinData -> BuiltinData)
-plutStan21CompiledCredentialValidator = undefined
+plutStan21CompiledCredentialValidator = undefined  -- stan-ignore: STAN-0212
 
 plutStan21BakedCredentialHelperFlow :: Tx.CompiledCode (BuiltinData -> BuiltinData)
 -- PLU-STAN-21 (should trigger): helper indirection before and after liftCodeDef still bakes the credential into the validator.
@@ -1466,7 +1466,7 @@ plutStan21ImmutableScriptHash =
   ScriptHash (BI.stringToBuiltinByteStringHex "deadbeef")
 
 plutStan21CompiledScriptHashValidator :: Tx.CompiledCode (ScriptHash -> BuiltinData -> BuiltinData)
-plutStan21CompiledScriptHashValidator = undefined
+plutStan21CompiledScriptHashValidator = undefined  -- stan-ignore: STAN-0212
 
 plutStan21BakedScriptHashMultilineApplyCode :: Either String (Tx.CompiledCode (BuiltinData -> BuiltinData))
 -- PLU-STAN-21 (should trigger): multiline ScriptHash specialization still bakes the hash into compiled code.
@@ -1478,7 +1478,7 @@ plutStan21BakedScriptHashMultilineApplyCode =
     )
 
 plutStan21CompiledIntegerValidator :: Tx.CompiledCode (Integer -> BuiltinData -> BuiltinData)
-plutStan21CompiledIntegerValidator = undefined
+plutStan21CompiledIntegerValidator = undefined  -- stan-ignore: STAN-0212
 
 plutStan21BakedIntegerShouldPass :: Tx.CompiledCode (BuiltinData -> BuiltinData)
 -- PLU-STAN-21 (should NOT trigger): non-credential parameters are out of scope.

--- a/target/Target/PlutusTx.hs
+++ b/target/Target/PlutusTx.hs
@@ -1405,3 +1405,123 @@ plutStan14RecordDestructureAddressEqShouldPass out ownAddress =
            OutputDatum _ -> True
            _ -> False
       && referenceScript == Nothing
+
+plutStan21ImmutableAdminKey :: PubKeyHash
+-- PLU-STAN-21 (should trigger): top-level credential constant is immutable.
+plutStan21ImmutableAdminKey =
+  PubKeyHash (BI.stringToBuiltinByteStringHex "deadbeef")
+
+plutStan21ImmutableStakeCredential :: StakingCredential
+-- PLU-STAN-21 (should trigger): top-level staking credential constant is immutable.
+plutStan21ImmutableStakeCredential =
+  StakingHash (PubKeyCredential plutStan21ImmutableAdminKey)
+
+plutStan21ImmutableAddress :: Address
+-- PLU-STAN-21 (should trigger): top-level address constant is immutable.
+plutStan21ImmutableAddress =
+  Address (PubKeyCredential plutStan21ImmutableAdminKey) (Just plutStan21ImmutableStakeCredential)
+
+plutStan21UnusedAdminKeyShouldPass :: PubKeyHash
+-- PLU-STAN-21 (should NOT trigger): top-level credentials outside compiled-validator specialization are out of scope.
+plutStan21UnusedAdminKeyShouldPass =
+  PubKeyHash (BI.stringToBuiltinByteStringHex "cafebabe")
+
+plutStan21CompiledAdminValidator :: Tx.CompiledCode (PubKeyHash -> BuiltinData -> BuiltinData)
+plutStan21CompiledAdminValidator = undefined
+
+plutStan21BakedLocalCredentialApplyCode :: Either String (Tx.CompiledCode (BuiltinData -> BuiltinData))
+-- PLU-STAN-21 (should trigger): locally scoped credentials specialized with applyCode are still baked into the validator.
+plutStan21BakedLocalCredentialApplyCode =
+  let localAdminKey :: PubKeyHash
+      localAdminKey = PubKeyHash (BI.stringToBuiltinByteStringHex "deadbeef")
+  in Tx.applyCode plutStan21CompiledAdminValidator (Tx.liftCodeDef localAdminKey)
+
+plutStan21CompiledAddressValidator :: Tx.CompiledCode (Address -> BuiltinData -> BuiltinData)
+plutStan21CompiledAddressValidator = undefined
+
+plutStan21BakedAddressUnsafeApplyCode :: Tx.CompiledCode (BuiltinData -> BuiltinData)
+-- PLU-STAN-21 (should trigger): credential-like address baked into compiled code via unsafeApplyCode.
+plutStan21BakedAddressUnsafeApplyCode =
+  plutStan21CompiledAddressValidator
+    `Tx.unsafeApplyCode` Tx.liftCodeDef plutStan21ImmutableAddress
+
+-- Intentionally left without a standalone type signature to exercise semantic binder-type detection.
+plutStan21ImplicitCredential =
+  PubKeyCredential plutStan21ImmutableAdminKey
+
+plutStan21CompiledCredentialValidator :: Tx.CompiledCode (Credential -> BuiltinData -> BuiltinData)
+plutStan21CompiledCredentialValidator = undefined
+
+plutStan21BakedCredentialHelperFlow :: Tx.CompiledCode (BuiltinData -> BuiltinData)
+-- PLU-STAN-21 (should trigger): helper indirection before and after liftCodeDef still bakes the credential into the validator.
+plutStan21BakedCredentialHelperFlow =
+  let credentialHelper = plutStan21ImplicitCredential
+      liftedCredential = Tx.liftCodeDef credentialHelper
+  in plutStan21CompiledCredentialValidator
+       `Tx.unsafeApplyCode` liftedCredential
+
+plutStan21ImmutableScriptHash :: ScriptHash
+-- PLU-STAN-21 (should trigger): top-level script hash specialized into validator code is immutable.
+plutStan21ImmutableScriptHash =
+  ScriptHash (BI.stringToBuiltinByteStringHex "deadbeef")
+
+plutStan21CompiledScriptHashValidator :: Tx.CompiledCode (ScriptHash -> BuiltinData -> BuiltinData)
+plutStan21CompiledScriptHashValidator = undefined
+
+plutStan21BakedScriptHashMultilineApplyCode :: Either String (Tx.CompiledCode (BuiltinData -> BuiltinData))
+-- PLU-STAN-21 (should trigger): multiline ScriptHash specialization still bakes the hash into compiled code.
+plutStan21BakedScriptHashMultilineApplyCode =
+  Tx.applyCode
+    plutStan21CompiledScriptHashValidator
+    ( Tx.liftCodeDef
+        plutStan21ImmutableScriptHash
+    )
+
+plutStan21CompiledIntegerValidator :: Tx.CompiledCode (Integer -> BuiltinData -> BuiltinData)
+plutStan21CompiledIntegerValidator = undefined
+
+plutStan21BakedIntegerShouldPass :: Tx.CompiledCode (BuiltinData -> BuiltinData)
+-- PLU-STAN-21 (should NOT trigger): non-credential parameters are out of scope.
+plutStan21BakedIntegerShouldPass =
+  plutStan21CompiledIntegerValidator
+    `Tx.unsafeApplyCode` Tx.liftCodeDef (42 :: Integer)
+
+plutStan21MatchBindLiftHelperFlow :: Tx.CompiledCode (BuiltinData -> BuiltinData)
+-- PLU-STAN-21 (should trigger): MatchBind helper functions that lift credentials still bake them into validator code.
+plutStan21MatchBindLiftHelperFlow =
+  let liftCredential :: Credential -> Tx.CompiledCode Credential
+      liftCredential cred = Tx.liftCodeDef cred
+      liftedCredential :: Tx.CompiledCode Credential
+      liftedCredential = liftCredential plutStan21ImplicitCredential
+  in plutStan21CompiledCredentialValidator
+       `Tx.unsafeApplyCode` liftedCredential
+
+plutStan21MixedLiftedTupleProjectionShouldPass :: Tx.CompiledCode (BuiltinData -> BuiltinData)
+-- PLU-STAN-21 (should NOT trigger): selecting a non-credential lifted value from a mixed helper binding stays out of scope.
+plutStan21MixedLiftedTupleProjectionShouldPass =
+  let liftedCredential :: Tx.CompiledCode Credential
+      liftedCredential = Tx.liftCodeDef plutStan21ImplicitCredential
+      liftedInteger :: Tx.CompiledCode Integer
+      liftedInteger = Tx.liftCodeDef (42 :: Integer)
+      liftedArgs :: (Tx.CompiledCode Credential, Tx.CompiledCode Integer)
+      liftedArgs = (liftedCredential, liftedInteger)
+      selectedInteger :: Tx.CompiledCode Integer
+      selectedInteger = case liftedArgs of
+        (_credentialArg, integerArg) -> integerArg
+  in plutStan21CompiledIntegerValidator
+       `Tx.unsafeApplyCode` selectedInteger
+
+plutStan21MixedLiftedTupleCredentialProjection :: Tx.CompiledCode (BuiltinData -> BuiltinData)
+-- PLU-STAN-21 (should trigger): selecting the credential-like lifted value from a mixed helper binding still bakes it into validator code.
+plutStan21MixedLiftedTupleCredentialProjection =
+  let liftedCredential :: Tx.CompiledCode Credential
+      liftedCredential = Tx.liftCodeDef plutStan21ImplicitCredential
+      liftedInteger :: Tx.CompiledCode Integer
+      liftedInteger = Tx.liftCodeDef (42 :: Integer)
+      liftedArgs :: (Tx.CompiledCode Credential, Tx.CompiledCode Integer)
+      liftedArgs = (liftedCredential, liftedInteger)
+      selectedCredential :: Tx.CompiledCode Credential
+      selectedCredential = case liftedArgs of
+        (credentialArg, _integerArg) -> credentialArg
+  in plutStan21CompiledCredentialValidator
+       `Tx.unsafeApplyCode` selectedCredential

--- a/test/Test/Stan/Analysis/PlutusTx.hs
+++ b/test/Test/Stan/Analysis/PlutusTx.hs
@@ -574,16 +574,16 @@ plustan21Spec analysis = describe "PLU-STAN-21" $ do
       checkNoObservation = noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan21
 
   it "flags validator-reachable top-level PubKeyHash constants" $
-    checkObservationMulti AntiPattern.plustan21 1411 1 2553 58
+    checkObservationMulti AntiPattern.plustan21 1411 1 1412 58
 
   it "flags validator-reachable top-level StakingCredential constants" $
-    checkObservationMulti AntiPattern.plustan21 1416 1 2558 61
+    checkObservationMulti AntiPattern.plustan21 1416 1 1417 61
 
   it "flags validator-reachable top-level Address constants" $
-    checkObservationMulti AntiPattern.plustan21 1421 1 2563 99
+    checkObservationMulti AntiPattern.plustan21 1421 1 1422 99
 
   it "does not flag top-level credentials that are never specialized" $
-    checkNoObservation 2567
+    checkNoObservation 1426
 
   it "flags locally scoped applyCode credentials in isolation" $
     checkObservation AntiPattern.plustan21 1437 68 81
@@ -592,25 +592,25 @@ plustan21Spec analysis = describe "PLU-STAN-21" $ do
     checkObservation AntiPattern.plustan21 1446 41 67
 
   it "flags top-level Credential bindings without explicit signatures" $
-    checkObservationMulti AntiPattern.plustan21 1449 1 2591 47
+    checkObservationMulti AntiPattern.plustan21 1449 1 1450 47
 
   it "flags helper-flow baked credentials passed via lifted helper bindings" $
     checkObservation AntiPattern.plustan21 1461 29 45
 
   it "flags validator-reachable top-level ScriptHash constants" $
-    checkObservationMulti AntiPattern.plustan21 1465 1 2607 58
+    checkObservationMulti AntiPattern.plustan21 1465 1 1466 58
 
   it "flags multiline ScriptHash specializations" $
     checkObservation AntiPattern.plustan21 1477 9 38
 
   it "does not flag non-credential lifted arguments" $
-    checkNoObservation 2626
+    checkNoObservation 1485
 
   it "flags MatchBind helper functions that lift credentials" $
     checkObservation AntiPattern.plustan21 1497 29 45
 
   it "does not flag mixed lifted bindings when only a non-credential projection is applied" $
-    checkNoObservation 2642
+    checkNoObservation 1501
 
   it "flags mixed lifted bindings when the credential projection is specialized" $
     checkObservation AntiPattern.plustan21 1527 29 47

--- a/test/Test/Stan/Analysis/PlutusTx.hs
+++ b/test/Test/Stan/Analysis/PlutusTx.hs
@@ -19,12 +19,13 @@ module Test.Stan.Analysis.PlutusTx (
   plustan17Spec,
   plustan18Spec,
   plustan19Spec,
+  plustan21Spec,
 ) where
 
 import Test.Hspec (Spec, describe, it)
 
 import Stan.Analysis (Analysis)
-import Test.Stan.Analysis.Common (noObservationAssert, observationAssert)
+import Test.Stan.Analysis.Common (noObservationAssert, observationAssert, observationAssertMulti)
 
 import qualified Stan.Inspection.AntiPattern as AntiPattern
 
@@ -49,6 +50,7 @@ analysisPlutusTxSpec analysis = describe "Plutus-Tx" $ do
   plustan17Spec analysis
   plustan18Spec analysis
   plustan19Spec analysis
+  plustan21Spec analysis
 
 plustan01Spec :: Analysis -> Spec
 plustan01Spec analysis = describe "PLU-STAN-01" $ do
@@ -564,3 +566,51 @@ plustan19Spec analysis = describe "PLU-STAN-19" $ do
 
   it "does not flag when all TxOut fields are checked" $
     noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan19 1010
+
+plustan21Spec :: Analysis -> Spec
+plustan21Spec analysis = describe "PLU-STAN-21" $ do
+  let checkObservation = observationAssert ["PlutusTx"] analysis
+      checkObservationMulti = observationAssertMulti ["PlutusTx"] analysis
+      checkNoObservation = noObservationAssert ["PlutusTx"] analysis AntiPattern.plustan21
+
+  it "flags validator-reachable top-level PubKeyHash constants" $
+    checkObservationMulti AntiPattern.plustan21 1411 1 2553 58
+
+  it "flags validator-reachable top-level StakingCredential constants" $
+    checkObservationMulti AntiPattern.plustan21 1416 1 2558 61
+
+  it "flags validator-reachable top-level Address constants" $
+    checkObservationMulti AntiPattern.plustan21 1421 1 2563 99
+
+  it "does not flag top-level credentials that are never specialized" $
+    checkNoObservation 2567
+
+  it "flags locally scoped applyCode credentials in isolation" $
+    checkObservation AntiPattern.plustan21 1437 68 81
+
+  it "flags credential-like address arguments baked in via unsafeApplyCode" $
+    checkObservation AntiPattern.plustan21 1446 41 67
+
+  it "flags top-level Credential bindings without explicit signatures" $
+    checkObservationMulti AntiPattern.plustan21 1449 1 2591 47
+
+  it "flags helper-flow baked credentials passed via lifted helper bindings" $
+    checkObservation AntiPattern.plustan21 1461 29 45
+
+  it "flags validator-reachable top-level ScriptHash constants" $
+    checkObservationMulti AntiPattern.plustan21 1465 1 2607 58
+
+  it "flags multiline ScriptHash specializations" $
+    checkObservation AntiPattern.plustan21 1477 9 38
+
+  it "does not flag non-credential lifted arguments" $
+    checkNoObservation 2626
+
+  it "flags MatchBind helper functions that lift credentials" $
+    checkObservation AntiPattern.plustan21 1497 29 45
+
+  it "does not flag mixed lifted bindings when only a non-credential projection is applied" $
+    checkNoObservation 2642
+
+  it "flags mixed lifted bindings when the credential projection is specialized" $
+    checkObservation AntiPattern.plustan21 1527 29 47


### PR DESCRIPTION
This pull request introduces a new automated detection rule, PLU-STAN-21, which warns against baking immutable credentials directly into Plutus validator code. It updates documentation, adds comprehensive test cases, and integrates the rule throughout the codebase to help developers avoid non-rotatable credentials that can compromise upgradability and security.

**New Rule: Immutable Credentials in Validators**

* Added rule PLU-STAN-21 to detect and warn when `PubKeyHash`, `Credential`, `StakingCredential`, `Address`, or `ScriptHash` values are hardcoded or specialized into validator code, as these cannot be rotated on-chain. The rule is documented in both `README.md` and `RULES.md`, with rationale and best practices. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R63) [[2]](diffhunk://#diff-a8ebbd66b8e411f87705f68905b9537f36a55e5d2154cd65bb0ab0e60acda150R258) [[3]](diffhunk://#diff-cc88ebddebab9854ab9d7b97c63f5f891b63524e30421aace41e6ddfdd79507eR520-R548)

**Implementation & Integration**

* Implemented the `ImmutableCredential` inspection and registered it as `plustan21` in the anti-pattern inspection map. This includes a detailed description, rationale, and suggested solutions for affected code. [[1]](diffhunk://#diff-4bb006f4b383db99126bf5f5dd336d897e7a3e1b577b315a35737daee60d6658R135-R136) [[2]](diffhunk://#diff-195164b5eb2284f9139b3fb2a26dbc6116bc661dfabf400e256311cad3abf192R70) [[3]](diffhunk://#diff-195164b5eb2284f9139b3fb2a26dbc6116bc661dfabf400e256311cad3abf192R137) [[4]](diffhunk://#diff-195164b5eb2284f9139b3fb2a26dbc6116bc661dfabf400e256311cad3abf192R831-R842)
* Updated imports to include `StakingCredential` for proper detection.

**Test Coverage**

* Added extensive test cases in `target/Target/PlutusTx.hs` to cover a wide variety of credential-baking scenarios, ensuring the rule triggers only when appropriate (e.g., not for unused or non-credential parameters).
* Integrated and expanded the test suite in `test/Test/Stan/Analysis/PlutusTx.hs` to verify the new rule's detection logic and edge cases. [[1]](diffhunk://#diff-8e859e2afba858ec196665cb4a86d37b5abc3e14df6a1f42c9800b442b9107b5R22-R28) [[2]](diffhunk://#diff-8e859e2afba858ec196665cb4a86d37b5abc3e14df6a1f42c9800b442b9107b5R53) [[3]](diffhunk://#diff-8e859e2afba858ec196665cb4a86d37b5abc3e14df6a1f42c9800b442b9107b5R569-R616)

**Tooling & Permissions**

* Updated `.claude/settings.json` to allow new test directories and shell commands relevant for the new rule's test cases.

These changes help prevent common upgradability and governance pitfalls in Plutus smart contracts by encouraging credentials to be managed on-chain, rather than hardcoded into validator logic.